### PR TITLE
Sowmika, Vineela, Sneha | BAH-846 | Multiple provider fix

### DIFF
--- a/api/src/main/java/org/openmrs/module/appointments/model/AppointmentProvider.java
+++ b/api/src/main/java/org/openmrs/module/appointments/model/AppointmentProvider.java
@@ -12,6 +12,7 @@ public class AppointmentProvider extends BaseOpenmrsData implements Serializable
     private Provider provider;
     private AppointmentProviderResponse response;
     private String comments;
+    private Boolean voided;
 
     @Override
     public Integer getId() {
@@ -61,5 +62,15 @@ public class AppointmentProvider extends BaseOpenmrsData implements Serializable
 
     public void setProvider(Provider provider) {
         this.provider = provider;
+    }
+
+    @Override
+    public Boolean getVoided() {
+        return voided;
+    }
+
+    @Override
+    public void setVoided(Boolean voided) {
+        this.voided = voided;
     }
 }

--- a/omod/src/main/java/org/openmrs/module/appointments/web/mapper/AppointmentMapper.java
+++ b/omod/src/main/java/org/openmrs/module/appointments/web/mapper/AppointmentMapper.java
@@ -191,6 +191,7 @@ public class AppointmentMapper {
 
     private List<AppointmentProviderDetail> mapAppointmentProviders(Set<AppointmentProvider> providers) {
         List<AppointmentProviderDetail> providerList = new ArrayList<>();
+        providers = getNonVoidedProviders(providers);
         if (providers != null) {
             for (AppointmentProvider apptProviderAssociation : providers) {
                 AppointmentProviderDetail providerDetail = new AppointmentProviderDetail();
@@ -202,6 +203,16 @@ public class AppointmentMapper {
             }
         }
         return providerList;
+    }
+
+    private Set<AppointmentProvider> getNonVoidedProviders(Set<AppointmentProvider> providers) {
+        if(providers == null || providers.isEmpty()) {
+            return providers;
+        }
+        providers = providers
+                .stream()
+                .filter(provider -> provider.getVoided() != Boolean.TRUE).collect(Collectors.toSet());
+        return providers;
     }
 
     private Map createServiceTypeMap(AppointmentServiceType s) {

--- a/omod/src/main/java/org/openmrs/module/appointments/web/mapper/AppointmentMapper.java
+++ b/omod/src/main/java/org/openmrs/module/appointments/web/mapper/AppointmentMapper.java
@@ -126,6 +126,8 @@ public class AppointmentMapper {
                     providers.forEach(existingAppointmentProvider -> {
                         //TODO: if currentUser is same person as provider, set ACCEPTED
                         existingAppointmentProvider.setResponse(mapProviderResponse(providerDetail.getResponse()));
+                        existingAppointmentProvider.setVoided(Boolean.FALSE);
+                        existingAppointmentProvider.setVoidReason(null);
                     });
                 }
             }

--- a/omod/src/test/java/org/openmrs/module/appointments/web/mapper/AppointmentMapperTest.java
+++ b/omod/src/test/java/org/openmrs/module/appointments/web/mapper/AppointmentMapperTest.java
@@ -482,4 +482,99 @@ public class AppointmentMapperTest {
         assertEquals(AppointmentProviderResponse.CANCELLED, appointmentProvider.getResponse());
 
     }
+
+    @Test
+    public void shouldReturnOnlyNonVoidedProvidersForAnAppointment() throws ParseException {
+        String appointmentUuid = "7869637c-12fe-4121-9692-b01f93f99e55";
+        Appointment appointment = createAppointment();
+        appointment.setUuid(appointmentUuid);
+        when(appointmentsService.getAppointmentByUuid(appointmentUuid)).thenReturn(appointment);
+        Provider anotherProvider = new Provider();
+        anotherProvider.setUuid("anotherProviderUuid");
+        when(providerService.getProviderByUuid("anotherProviderUuid")).thenReturn(anotherProvider);
+        AppointmentProvider appointmentProvider = new AppointmentProvider();
+        AppointmentProvider anotherAppointmentProvider = new AppointmentProvider();
+        appointmentProvider.setProvider(provider);
+        anotherAppointmentProvider.setProvider(anotherProvider);
+        appointmentProvider.setResponse(AppointmentProviderResponse.ACCEPTED);
+        anotherAppointmentProvider.setResponse(AppointmentProviderResponse.CANCELLED);
+        appointmentProvider.setVoided(false);
+        anotherAppointmentProvider.setVoided(true);
+
+        Set<AppointmentProvider> appProviders = new HashSet<>();
+        appProviders.add(appointmentProvider);
+        appProviders.add(anotherAppointmentProvider);
+        appointment.setProviders(appProviders);
+
+        AppointmentDefaultResponse appointmentDefaultResponse = appointmentMapper.constructResponse(appointment);
+
+        assertEquals(1, appointmentDefaultResponse.getProviders().size());
+        assertEquals("providerUuid", appointmentDefaultResponse.getProviders().get(0).getUuid());
+    }
+
+    @Test
+    public void shouldReturnOnlyNonVoidedProvidersForListOfAppointments() throws ParseException {
+        String appointmentUuid = "7869637c-12fe-4121-9692-b01f93f99e55";
+        Appointment appointment = createAppointment();
+        appointment.setUuid(appointmentUuid);
+        String anotherAppointmentUuid = "7869637c-12fe-4121-9692-b01f93f99e56";
+        Appointment anotherAppointment = createAppointment();
+        anotherAppointment.setUuid(anotherAppointmentUuid);
+        when(appointmentsService.getAppointmentByUuid(appointmentUuid)).thenReturn(appointment);
+        when(appointmentsService.getAppointmentByUuid(anotherAppointmentUuid)).thenReturn(anotherAppointment);
+        Provider anotherProvider = new Provider();
+        anotherProvider.setUuid("anotherProviderUuid");
+        when(providerService.getProviderByUuid("anotherProviderUuid")).thenReturn(anotherProvider);
+
+        AppointmentProvider appointmentProvider = new AppointmentProvider();
+        appointmentProvider.setProvider(provider);
+        appointmentProvider.setResponse(AppointmentProviderResponse.ACCEPTED);
+        appointmentProvider.setVoided(false);
+        AppointmentProvider anotherAppointmentProvider = new AppointmentProvider();
+        anotherAppointmentProvider.setProvider(anotherProvider);
+        anotherAppointmentProvider.setResponse(AppointmentProviderResponse.CANCELLED);
+        anotherAppointmentProvider.setVoided(true);
+
+        Set<AppointmentProvider> appProviders = new HashSet<>();
+        appProviders.add(appointmentProvider);
+        appointment.setProviders(appProviders);
+        Set<AppointmentProvider> anotherAppProviders = new HashSet<>();
+        anotherAppProviders.add(anotherAppointmentProvider);
+        anotherAppointment.setProviders(anotherAppProviders);
+        List<Appointment> appointments = Arrays.asList(appointment, anotherAppointment);
+
+        List<AppointmentDefaultResponse> appointmentDefaultResponses = appointmentMapper.constructResponse(appointments);
+
+        assertEquals(1, appointmentDefaultResponses.get(0).getProviders().size());
+        assertEquals(0, appointmentDefaultResponses.get(1).getProviders().size());
+        assertEquals("providerUuid", appointmentDefaultResponses.get(0).getProviders().get(0).getUuid());
+    }
+
+    @Test
+    public void shouldReturnEmptyListWhenProvidersAreNullForAnAppointment() throws ParseException {
+        String appointmentUuid = "7869637c-12fe-4121-9692-b01f93f99e55";
+        Appointment appointment = createAppointment();
+        appointment.setUuid(appointmentUuid);
+        when(appointmentsService.getAppointmentByUuid(appointmentUuid)).thenReturn(appointment);
+        appointment.setProvider(null);
+        appointment.setProviders(null);
+
+        AppointmentDefaultResponse appointmentDefaultResponse = appointmentMapper.constructResponse(appointment);
+
+        assertEquals(Collections.EMPTY_LIST, appointmentDefaultResponse.getProviders());
+    }
+
+    @Test
+    public void shouldReturnEmptyListWhenProvidersListIsEmptyForAnAppointment() throws ParseException {
+        String appointmentUuid = "7869637c-12fe-4121-9692-b01f93f99e55";
+        Appointment appointment = createAppointment();
+        appointment.setUuid(appointmentUuid);
+        when(appointmentsService.getAppointmentByUuid(appointmentUuid)).thenReturn(appointment);
+        appointment.setProvider(null);
+        appointment.setProviders(Collections.EMPTY_SET);
+
+        AppointmentDefaultResponse appointmentDefaultResponse = appointmentMapper.constructResponse(appointment);
+
+        assertEquals(Collections.EMPTY_LIST, appointmentDefaultResponse.getProviders());
+    }
 }

--- a/omod/src/test/java/org/openmrs/module/appointments/web/mapper/AppointmentMapperTest.java
+++ b/omod/src/test/java/org/openmrs/module/appointments/web/mapper/AppointmentMapperTest.java
@@ -577,4 +577,28 @@ public class AppointmentMapperTest {
 
         assertEquals(Collections.EMPTY_LIST, appointmentDefaultResponse.getProviders());
     }
+
+    @Test
+    public void shouldChangeTheResponseAndVoidedDataWhenProviderIsVoidedAndAddedAgain() throws ParseException {
+        String appointmentUuid = "7869637c-12fe-4121-9692-b01f93f99e55";
+        Appointment existingAppointment = createAppointment();
+        existingAppointment.setUuid(appointmentUuid);
+        AppointmentProvider appointmentProvider = new AppointmentProvider();
+        appointmentProvider.setProvider(provider);
+        appointmentProvider.setResponse(AppointmentProviderResponse.ACCEPTED);
+        Set<AppointmentProvider> appProviders = new HashSet<>();
+        appProviders.add(appointmentProvider);
+        existingAppointment.setProviders(appProviders);
+        appointmentProvider.setVoided(true);
+        when(appointmentsService.getAppointmentByUuid(appointmentUuid)).thenReturn(existingAppointment);
+        AppointmentRequest appointmentRequest = createAppointmentRequest();
+        appointmentRequest.setUuid(appointmentUuid);
+
+        Appointment appointment = appointmentMapper.fromRequest(appointmentRequest);
+
+        assertEquals(((AppointmentProvider)appointment.getProviders().toArray()[0]).getVoided(), false);
+        assertEquals(((AppointmentProvider)appointment.getProviders().toArray()[0]).getResponse(),
+                AppointmentProviderResponse.ACCEPTED);
+        assertEquals(((AppointmentProvider)appointment.getProviders().toArray()[0]).getVoidReason(), null);
+    }
 }


### PR DESCRIPTION
Fix to following issue due to multiple provider:

Issue 1 - Duplicate Appointments:

1. Create an appointment with a provider.2. Now, click on edit of that appointment and remove the provider and add a new provider and save.3. It will retain the old appointment on the calendar and also show a new appointment. The list view works correctly.

Issue 2 - Cannot edit provider name again:

1. Create an appointment with a provider.2. Now, click on edit of that appointment and remove the provider and add a new provider and save.

3. Now, click on edit of that appointment and remove the provider and add a new provider, we will not be able to add it.

4. If we click on save without a provider name, it will not edit the current chosen appointment, but the duplicate appointment created in step 2. And we can still see provider in list view.