### PR TITLE
Dubey | AP-7 | Add changeset to add global-propertry to figure out instance type.

### DIFF
--- a/api/src/main/resources/liquibase.xml
+++ b/api/src/main/resources/liquibase.xml
@@ -470,4 +470,15 @@
             <column name="uuid" valueComputed="UUID()"/>
         </insert>
     </changeSet>
+    <changeSet id="201910091141" author="Dubey">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">select count(*) from global_property where property='bahmni.appointments.runningOnOpenMRS'</sqlCheck>
+        </preConditions>
+        <comment>Adding 'bahmni.appointments.runningOnOpenMRS' global property to figure out instance type</comment>
+        <insert tableName="global_property">
+            <column name="property" value="bahmni.appointments.runningOnOpenMRS"/>
+            <column name="uuid" valueComputed="UUID()"/>
+            <column name="description" value="If set to yes, the appointments ui will run independent of bahmni core"/>
+        </insert>
+    </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
As part of this PR, a new `global_property` named `bahmni.appointments.runningOnOpenmrs` will be added. When set to `true` the `appointments-ui-app` will fetch bahmni specific cookies while initialization.

This is being done as part of Enabling Appointments Application to run on OpenMRS. Below is the link to the card.
https://bahmni.atlassian.net/browse/AP-7