### PR TITLE
AP-36 | Enable appointment requests

### DIFF
--- a/api/src/main/java/org/openmrs/module/appointments/dao/AppointmentDao.java
+++ b/api/src/main/java/org/openmrs/module/appointments/dao/AppointmentDao.java
@@ -14,7 +14,7 @@ public interface AppointmentDao {
     List<Appointment> getAllAppointments(Date forDate);
 
     @Transactional
-    void save(Appointment appointmentService);
+    void save(Appointment appointment);
 
     List<Appointment> search(Appointment appointment);
 

--- a/api/src/main/java/org/openmrs/module/appointments/model/AppointmentServiceDefinition.java
+++ b/api/src/main/java/org/openmrs/module/appointments/model/AppointmentServiceDefinition.java
@@ -23,6 +23,7 @@ public class AppointmentServiceDefinition extends BaseOpenmrsData implements Ser
     private Integer durationMins;
     private Location location;
     private String  color;
+    private AppointmentStatus initialAppointmentStatus;
     private Set<ServiceWeeklyAvailability> weeklyAvailability;
     private Set<AppointmentServiceType> serviceTypes;
 
@@ -163,5 +164,13 @@ public class AppointmentServiceDefinition extends BaseOpenmrsData implements Ser
 
     public void setColor(String color) {
         this.color = color;
+    }
+
+    public AppointmentStatus getInitialAppointmentStatus() {
+        return initialAppointmentStatus;
+    }
+
+    public void setInitialAppointmentStatus(AppointmentStatus initialAppointmentStatus) {
+        this.initialAppointmentStatus = initialAppointmentStatus;
     }
 }

--- a/api/src/main/java/org/openmrs/module/appointments/model/AppointmentStatus.java
+++ b/api/src/main/java/org/openmrs/module/appointments/model/AppointmentStatus.java
@@ -1,7 +1,7 @@
 package org.openmrs.module.appointments.model;
 
 public enum AppointmentStatus {
-    Scheduled("Scheduled", 0), CheckedIn("CheckedIn", 1), Completed("Completed", 2), Cancelled("Cancelled", 2), Missed("Missed", 2);
+    Requested("Requested", 0), Scheduled("Scheduled", 1), CheckedIn("CheckedIn", 2), Completed("Completed", 3), Cancelled("Cancelled", 3), Missed("Missed", 3);
 
     private final String value;
     private final int sequence;

--- a/api/src/main/java/org/openmrs/module/appointments/service/AppointmentsService.java
+++ b/api/src/main/java/org/openmrs/module/appointments/service/AppointmentsService.java
@@ -62,7 +62,7 @@ public interface AppointmentsService {
     void undoStatusChange(Appointment appointment);
 
     @Transactional
-    @Authorized({MANAGE_APPOINTMENTS})
+    @Authorized({MANAGE_APPOINTMENTS, MANAGE_OWN_APPOINTMENTS})
     void updateAppointmentProviderResponse(AppointmentProvider appointmentProviderProvider);
 
     @Transactional

--- a/api/src/main/java/org/openmrs/module/appointments/service/impl/AppointmentsServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/appointments/service/impl/AppointmentsServiceImpl.java
@@ -3,7 +3,7 @@ package org.openmrs.module.appointments.service.impl;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.hibernate.cfg.NotYetImplementedException;
+import org.openmrs.Person;
 import org.openmrs.api.APIAuthenticationException;
 import org.openmrs.api.APIException;
 import org.openmrs.api.context.Context;
@@ -34,7 +34,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import static java.util.Objects.isNull;
@@ -45,9 +44,8 @@ import static org.openmrs.module.appointments.util.DateUtil.getStartOfDay;
 @Transactional
 public class AppointmentsServiceImpl implements AppointmentsService {
 
-    private Log log = LogFactory.getLog(this.getClass());
     private static final String PRIVILEGES_EXCEPTION_CODE = "error.privilegesRequired";
-
+    private Log log = LogFactory.getLog(this.getClass());
     private AppointmentDao appointmentDao;
 
     private List<AppointmentStatusChangeValidator> statusChangeValidators;
@@ -78,9 +76,9 @@ public class AppointmentsServiceImpl implements AppointmentsService {
         this.appointmentAuditDao = appointmentAuditDao;
     }
 
-	public void setAppointmentServiceHelper(AppointmentServiceHelper appointmentServiceHelper) {
-		this.appointmentServiceHelper = appointmentServiceHelper;
-	}
+    public void setAppointmentServiceHelper(AppointmentServiceHelper appointmentServiceHelper) {
+        this.appointmentServiceHelper = appointmentServiceHelper;
+    }
 
     public void setEditAppointmentValidators(List<AppointmentValidator> editAppointmentValidators) {
         this.editAppointmentValidators = editAppointmentValidators;
@@ -103,12 +101,12 @@ public class AppointmentsServiceImpl implements AppointmentsService {
     private boolean isCurrentUserSamePersonAsOneOfTheAppointmentProviders(Set<AppointmentProvider> providers) {
         return providers.stream()
                 .anyMatch(provider -> provider.getProvider().getPerson().
-                equals(Context.getAuthenticatedUser().getPerson()));
+                        equals(Context.getAuthenticatedUser().getPerson()));
     }
 
     @Override
     public Appointment validateAndSave(Appointment appointment) throws APIException {
-        validate(appointment, appointmentValidators );
+        validate(appointment, appointmentValidators);
         appointmentServiceHelper.checkAndAssignAppointmentNumber(appointment);
         save(appointment);
         return appointment;
@@ -123,7 +121,7 @@ public class AppointmentsServiceImpl implements AppointmentsService {
     public void validate(Appointment appointment, List<AppointmentValidator> appointmentValidators) {
         if (!validateIfUserHasSelfOrAllAppointmentsAccess(appointment)) {
             throw new APIAuthenticationException(Context.getMessageSourceService().getMessage(PRIVILEGES_EXCEPTION_CODE,
-                    new Object[] { MANAGE_APPOINTMENTS }, null));
+                    new Object[]{MANAGE_APPOINTMENTS}, null));
         }
         appointmentServiceHelper.validate(appointment, appointmentValidators);
     }
@@ -141,6 +139,7 @@ public class AppointmentsServiceImpl implements AppointmentsService {
 
     /**
      * TODO: refactor. How can a search by an appointment return a list of appointments?
+     *
      * @param appointment
      * @return
      */
@@ -172,7 +171,7 @@ public class AppointmentsServiceImpl implements AppointmentsService {
     }
 
     @Override
-    public void changeStatus(Appointment appointment, String status, Date onDate) throws APIException{
+    public void changeStatus(Appointment appointment, String status, Date onDate) throws APIException {
         AppointmentStatus appointmentStatus = AppointmentStatus.valueOf(status);
         validateUserPrivilege(appointment, appointmentStatus);
         appointmentServiceHelper.validateStatusChangeAndGetErrors(appointment, appointmentStatus, statusChangeValidators);
@@ -188,14 +187,16 @@ public class AppointmentsServiceImpl implements AppointmentsService {
             throw new APIAuthenticationException(Context.getMessageSourceService().getMessage(PRIVILEGES_EXCEPTION_CODE,
                     new Object[]{MANAGE_APPOINTMENTS}, null));
         }
-        if (!isUserAllowedToResetStatus(appointmentStatus)) {
+        if (!isUserAllowedToResetStatus(appointmentStatus, appointment.getStatus())) {
             throw new APIAuthenticationException(Context.getMessageSourceService().getMessage(PRIVILEGES_EXCEPTION_CODE,
                     new Object[]{RESET_APPOINTMENT_STATUS}, null));
         }
     }
 
-    private boolean isUserAllowedToResetStatus(AppointmentStatus appointmentStatus) {
-        return appointmentStatus != AppointmentStatus.Scheduled || Context.hasPrivilege(RESET_APPOINTMENT_STATUS);
+    private boolean isUserAllowedToResetStatus(AppointmentStatus toStatus, AppointmentStatus currentStatus) {
+        if (!toStatus.equals(AppointmentStatus.Scheduled)) return true;
+        if (currentStatus.equals(AppointmentStatus.Requested)) return true;
+        return Context.hasPrivilege(RESET_APPOINTMENT_STATUS);
     }
 
     @Override
@@ -205,10 +206,10 @@ public class AppointmentsServiceImpl implements AppointmentsService {
     }
 
     @Override
-    public void undoStatusChange(Appointment appointment) throws APIException{
+    public void undoStatusChange(Appointment appointment) throws APIException {
         if (!validateIfUserHasSelfOrAllAppointmentsAccess(appointment)) {
             throw new APIAuthenticationException(Context.getMessageSourceService().getMessage(PRIVILEGES_EXCEPTION_CODE,
-                    new Object[] { MANAGE_APPOINTMENTS }, null));
+                    new Object[]{MANAGE_APPOINTMENTS}, null));
         }
         AppointmentAudit statusChangeEvent = appointmentAuditDao.getPriorStatusChangeEvent(appointment);
         if (statusChangeEvent != null) {
@@ -260,24 +261,35 @@ public class AppointmentsServiceImpl implements AppointmentsService {
         Appointment appointment = appointmentProviderProvider.getAppointment();
         Set<AppointmentProvider> providers = appointment.getProviders();
 
-        if (CollectionUtils.isEmpty(providers)){
+        if (CollectionUtils.isEmpty(providers)) {
             throw new APIException("No providers present in Appointment");
         }
-
-        Optional<AppointmentProvider> providerInAppointment = providers.stream().filter(
-                provider -> provider.getProvider().equals(appointmentProviderProvider.getProvider())
-        ).findFirst();
-        if (!providerInAppointment.isPresent()){
-            throw new APIException("Provider is not part of Appointment");
-        }
-        AppointmentProvider appointmentProvider = providerInAppointment.get();
+        AppointmentProvider appointmentProvider = findProviderInAppointment(appointmentProviderProvider, providers);
+        validateProviderResponseForSelf(appointmentProvider);
         appointmentProvider.setResponse(appointmentProviderProvider.getResponse());
-        if (isFirstAcceptForRequestedAppointment(appointmentProviderProvider, appointment)){
+
+        if (isFirstAcceptForRequestedAppointment(appointmentProviderProvider, appointment)) {
             changeStatus(appointment, AppointmentStatus.Scheduled.name(), Date.from(Instant.now()));
-        }else{
+        } else {
             appointmentDao.save(appointment);
         }
         createAppointmentAudit(appointmentProviderProvider, appointment, appointmentProvider);
+    }
+
+    private AppointmentProvider findProviderInAppointment(AppointmentProvider appointmentProviderProvider, Set<AppointmentProvider> providers) {
+        Optional<AppointmentProvider> providerInAppointment = providers.stream().filter(
+                provider -> provider.getProvider().equals(appointmentProviderProvider.getProvider())
+        ).findFirst();
+        if (!providerInAppointment.isPresent()) throw new APIException("Provider is not part of Appointment");
+        return providerInAppointment.get();
+    }
+
+    private void validateProviderResponseForSelf(AppointmentProvider appointmentProvider) {
+        Person loggedInPerson = Context.getAuthenticatedUser().getPerson();
+        Person providerPerson = appointmentProvider.getProvider().getPerson();
+        if (!loggedInPerson.equals(providerPerson)) {
+            throw new APIAuthenticationException("Cannot change Provider Response for other providers");
+        }
     }
 
     @Override

--- a/api/src/main/java/org/openmrs/module/appointments/validator/impl/DefaultAppointmentStatusChangeValidator.java
+++ b/api/src/main/java/org/openmrs/module/appointments/validator/impl/DefaultAppointmentStatusChangeValidator.java
@@ -17,10 +17,14 @@ public class DefaultAppointmentStatusChangeValidator implements AppointmentStatu
         boolean disableValidation = disableDefaultValidationValue != null ? Boolean.valueOf(disableDefaultValidationValue) : false;
         if (!disableValidation) {
             AppointmentStatus currentStatus = appointment.getStatus();
-            if (toStatus.getSequence() <= currentStatus.getSequence() && toStatus != AppointmentStatus.Scheduled) {
+            if (toStatus.getSequence() <= currentStatus.getSequence() && inNotInitialAppointmentStatus(toStatus)) {
 				errors.add("Appointment status can not be changed from " + appointment.getStatus() + " to " + toStatus);
 			}
         }
+    }
+
+    private boolean inNotInitialAppointmentStatus(AppointmentStatus toStatus) {
+        return toStatus != AppointmentStatus.Scheduled && toStatus != AppointmentStatus.Requested;
     }
 
 }

--- a/api/src/main/java/org/openmrs/module/appointments/validator/impl/DefaultAppointmentStatusChangeValidator.java
+++ b/api/src/main/java/org/openmrs/module/appointments/validator/impl/DefaultAppointmentStatusChangeValidator.java
@@ -17,14 +17,10 @@ public class DefaultAppointmentStatusChangeValidator implements AppointmentStatu
         boolean disableValidation = disableDefaultValidationValue != null ? Boolean.valueOf(disableDefaultValidationValue) : false;
         if (!disableValidation) {
             AppointmentStatus currentStatus = appointment.getStatus();
-            if (toStatus.getSequence() <= currentStatus.getSequence() && inNotInitialAppointmentStatus(toStatus)) {
-				errors.add("Appointment status can not be changed from " + appointment.getStatus() + " to " + toStatus);
-			}
+            if (toStatus.getSequence() <= currentStatus.getSequence() && toStatus != AppointmentStatus.Scheduled) {
+                errors.add("Appointment status can not be changed from " + appointment.getStatus() + " to " + toStatus);
+            }
         }
-    }
-
-    private boolean inNotInitialAppointmentStatus(AppointmentStatus toStatus) {
-        return toStatus != AppointmentStatus.Scheduled && toStatus != AppointmentStatus.Requested;
     }
 
 }

--- a/api/src/main/resources/AppointmentServiceDefinition.hbm.xml
+++ b/api/src/main/resources/AppointmentServiceDefinition.hbm.xml
@@ -16,6 +16,12 @@
         <property name="maxAppointmentsLimit" type="java.lang.Integer" column="max_appointments_limit"/>
         <property name="durationMins" type="java.lang.Integer" column="duration_mins"/>
         <property name="color" type="java.lang.String" column="color" length="8" not-null="false" />
+        <property name="initialAppointmentStatus" column="initial_appointment_status">
+            <type name="org.hibernate.type.EnumType">
+                <param name="enumClass">org.openmrs.module.appointments.model.AppointmentStatus</param>
+                <param name="useNamed">true</param>
+            </type>
+        </property>
 
         <property name="dateCreated" type="java.util.Date" column="date_created"/>
         <property name="dateChanged" type="java.util.Date" column="date_changed"/>

--- a/api/src/main/resources/liquibase.xml
+++ b/api/src/main/resources/liquibase.xml
@@ -538,5 +538,15 @@
         </sql>
 
     </changeSet>
+    <changeSet id="add_initial_appointment_status_appointment_service" author="Dubey">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists columnName="initial_appointment_status" tableName="appointment_service"/>
+            </not>
+        </preConditions>
+        <addColumn tableName="appointment_service">
+            <column name="initial_appointment_status" type="varchar(45)"/>
+        </addColumn>
+    </changeSet>
 
 </databaseChangeLog>

--- a/api/src/test/java/org/openmrs/module/appointments/validator/impl/DefaultAppointmentStatusChangeValidatorTest.java
+++ b/api/src/test/java/org/openmrs/module/appointments/validator/impl/DefaultAppointmentStatusChangeValidatorTest.java
@@ -272,13 +272,4 @@ public class DefaultAppointmentStatusChangeValidatorTest {
         validator.validate(appointment, AppointmentStatus.Scheduled, errors);
         assertEquals(0, errors.size());
     }
-
-    @Test
-    public void shouldChangeStatusFromCheckedInToRequested() {
-        when(administrationService.getGlobalProperty("disableDefaultAppointmentValidations")).thenReturn("true");
-        appointment.setStatus(AppointmentStatus.CheckedIn);
-        List<String> errors = new ArrayList<>();
-        validator.validate(appointment, AppointmentStatus.Requested, errors);
-        assertEquals(0, errors.size());
-    }
 }

--- a/api/src/test/java/org/openmrs/module/appointments/validator/impl/DefaultAppointmentStatusChangeValidatorTest.java
+++ b/api/src/test/java/org/openmrs/module/appointments/validator/impl/DefaultAppointmentStatusChangeValidatorTest.java
@@ -272,4 +272,13 @@ public class DefaultAppointmentStatusChangeValidatorTest {
         validator.validate(appointment, AppointmentStatus.Scheduled, errors);
         assertEquals(0, errors.size());
     }
+
+    @Test
+    public void shouldChangeStatusFromCheckedInToRequested() {
+        when(administrationService.getGlobalProperty("disableDefaultAppointmentValidations")).thenReturn("true");
+        appointment.setStatus(AppointmentStatus.CheckedIn);
+        List<String> errors = new ArrayList<>();
+        validator.validate(appointment, AppointmentStatus.Requested, errors);
+        assertEquals(0, errors.size());
+    }
 }

--- a/omod/src/main/java/org/openmrs/module/appointments/web/contract/AppointmentRequest.java
+++ b/omod/src/main/java/org/openmrs/module/appointments/web/contract/AppointmentRequest.java
@@ -19,6 +19,7 @@ public class AppointmentRequest {
     private String locationUuid;
     private Date startDateTime;
     private Date endDateTime;
+    private String status;
     private String appointmentKind;
     private String comments;
     private List<AppointmentProviderDetail> providers = new ArrayList<>();
@@ -101,6 +102,14 @@ public class AppointmentRequest {
 
     public void setAppointmentKind(String appointmentKind) {
         this.appointmentKind = appointmentKind;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
     }
 
     public String getComments() {

--- a/omod/src/main/java/org/openmrs/module/appointments/web/contract/AppointmentServiceDefaultResponse.java
+++ b/omod/src/main/java/org/openmrs/module/appointments/web/contract/AppointmentServiceDefaultResponse.java
@@ -14,6 +14,7 @@ public class AppointmentServiceDefaultResponse {
 	private Map location;
 	private String uuid;
 	private String color;
+	private String initialAppointmentStatus;
 	private String creatorName;
 
 	public Integer getAppointmentServiceId() {
@@ -110,5 +111,14 @@ public class AppointmentServiceDefaultResponse {
 
 	public void setColor(String color) {
 		this.color = color;
+	}
+
+
+	public String getInitialAppointmentStatus() {
+		return initialAppointmentStatus;
+	}
+
+	public void setInitialAppointmentStatus(String initialAppointmentStatus) {
+		this.initialAppointmentStatus = initialAppointmentStatus;
 	}
 }

--- a/omod/src/main/java/org/openmrs/module/appointments/web/contract/AppointmentServiceDescription.java
+++ b/omod/src/main/java/org/openmrs/module/appointments/web/contract/AppointmentServiceDescription.java
@@ -19,6 +19,7 @@ public class AppointmentServiceDescription {
     private String locationUuid;
     private String uuid;
     private String color;
+    private String initialAppointmentStatus;
     private List<ServiceWeeklyAvailabilityDescription> weeklyAvailability;
     private Set<AppointmentServiceTypeDescription> serviceTypes;
 
@@ -117,5 +118,13 @@ public class AppointmentServiceDescription {
 
     public void setColor(String color) {
         this.color = color;
+    }
+
+    public String getInitialAppointmentStatus() {
+        return initialAppointmentStatus;
+    }
+
+    public void setInitialAppointmentStatus(String initialAppointmentStatus) {
+        this.initialAppointmentStatus = initialAppointmentStatus;
     }
 }

--- a/omod/src/main/java/org/openmrs/module/appointments/web/controller/AppointmentController.java
+++ b/omod/src/main/java/org/openmrs/module/appointments/web/controller/AppointmentController.java
@@ -99,6 +99,7 @@ public class AppointmentController {
                     appointmentsService.getAppointmentsForService(
                             appointmentServiceDefinition, startDate, endDate,
                             Arrays.asList(
+                                    AppointmentStatus.Requested,
                                     AppointmentStatus.Completed,
                                     AppointmentStatus.Scheduled,
                                     AppointmentStatus.CheckedIn,

--- a/omod/src/main/java/org/openmrs/module/appointments/web/controller/AppointmentsController.java
+++ b/omod/src/main/java/org/openmrs/module/appointments/web/controller/AppointmentsController.java
@@ -3,10 +3,12 @@ package org.openmrs.module.appointments.web.controller;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.openmrs.module.appointments.model.Appointment;
+import org.openmrs.module.appointments.model.AppointmentProvider;
 import org.openmrs.module.appointments.model.AppointmentSearchRequest;
 import org.openmrs.module.appointments.service.AppointmentsService;
 import org.openmrs.module.appointments.util.DateUtil;
 import org.openmrs.module.appointments.web.contract.AppointmentDefaultResponse;
+import org.openmrs.module.appointments.web.contract.AppointmentProviderDetail;
 import org.openmrs.module.appointments.web.contract.AppointmentRequest;
 import org.openmrs.module.appointments.web.mapper.AppointmentMapper;
 import org.openmrs.module.appointments.web.validators.AppointmentSearchValidator;
@@ -120,4 +122,23 @@ public class AppointmentsController {
             return new ResponseEntity<>(RestUtil.wrapErrorResponse(e, e.getMessage()), HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
+
+    @RequestMapping(method = RequestMethod.POST, value="/{appointmentUuid}/providerResponse")
+    @ResponseBody
+    public ResponseEntity<Object> updateAppointmentProviderResponse(@PathVariable("appointmentUuid")String appointmentUuid, @RequestBody AppointmentProviderDetail providerResponse) throws ParseException {
+        try {
+            Appointment appointment = appointmentsService.getAppointmentByUuid(appointmentUuid);
+            if(appointment == null){
+                throw new RuntimeException("Appointment does not exist");
+            }
+            AppointmentProvider appointmentProviderProvider = appointmentMapper.mapAppointmentProvider(providerResponse);
+            appointmentProviderProvider.setAppointment(appointment);
+            appointmentsService.updateAppointmentProviderResponse(appointmentProviderProvider);
+            return new ResponseEntity<>(HttpStatus.OK);
+        }catch (RuntimeException e) {
+            log.error("Runtime error while trying to update appointment provider response", e);
+            return new ResponseEntity<>(RestUtil.wrapErrorResponse(e, e.getMessage()), HttpStatus.BAD_REQUEST);
+        }
+    }
+
 }

--- a/omod/src/main/java/org/openmrs/module/appointments/web/mapper/AppointmentMapper.java
+++ b/omod/src/main/java/org/openmrs/module/appointments/web/mapper/AppointmentMapper.java
@@ -90,6 +90,9 @@ public class AppointmentMapper {
         if (appointmentRequest.getServiceTypeUuid() != null) {
             appointmentServiceType = getServiceTypeByUuid(appointmentServiceDefinition.getServiceTypes(true), appointmentRequest.getServiceTypeUuid());
         }
+        if (StringUtils.isNotBlank(appointmentRequest.getStatus())){
+            appointment.setStatus(AppointmentStatus.valueOf(appointmentRequest.getStatus()));
+        }
         appointment.setServiceType(appointmentServiceType);
         appointment.setService(appointmentServiceDefinition);
         //appointment.setProvider(identifyAppointmentProvider(appointmentRequest.getProviderUuid()));

--- a/omod/src/main/java/org/openmrs/module/appointments/web/mapper/AppointmentServiceMapper.java
+++ b/omod/src/main/java/org/openmrs/module/appointments/web/mapper/AppointmentServiceMapper.java
@@ -6,6 +6,7 @@ import org.openmrs.api.LocationService;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.appointments.model.AppointmentServiceDefinition;
 import org.openmrs.module.appointments.model.AppointmentServiceType;
+import org.openmrs.module.appointments.model.AppointmentStatus;
 import org.openmrs.module.appointments.model.ServiceWeeklyAvailability;
 import org.openmrs.module.appointments.model.Speciality;
 import org.openmrs.module.appointments.service.AppointmentServiceDefinitionService;
@@ -43,6 +44,13 @@ public class AppointmentServiceMapper {
         appointmentServiceDefinition.setEndTime(appointmentServiceDescription.getEndTime());
         appointmentServiceDefinition.setMaxAppointmentsLimit(appointmentServiceDescription.getMaxAppointmentsLimit());
         appointmentServiceDefinition.setColor(appointmentServiceDescription.getColor());
+
+        String initialAppointmentStatus = appointmentServiceDescription.getInitialAppointmentStatus();
+        if (StringUtils.isNotBlank(initialAppointmentStatus)) {
+            appointmentServiceDefinition.setInitialAppointmentStatus(AppointmentStatus.valueOf(initialAppointmentStatus));
+        }else {
+            appointmentServiceDefinition.setInitialAppointmentStatus(null);
+        }
 
         String locationUuid = appointmentServiceDescription.getLocationUuid();
         Location location = locationService.getLocationByUuid(locationUuid);
@@ -160,6 +168,11 @@ public class AppointmentServiceMapper {
         asResponse.setDurationMins(as.getDurationMins());
         asResponse.setMaxAppointmentsLimit(as.getMaxAppointmentsLimit());
         asResponse.setColor(as.getColor());
+
+        AppointmentStatus initialAppointmentStatus = as.getInitialAppointmentStatus();
+        if (null != initialAppointmentStatus){
+            asResponse.setInitialAppointmentStatus(initialAppointmentStatus.name());
+        }
 
         Map specialityMap = new HashMap();
         Speciality speciality = as.getSpeciality();

--- a/omod/src/test/java/org/openmrs/module/appointments/web/controller/AppointmentControllerIT.java
+++ b/omod/src/test/java/org/openmrs/module/appointments/web/controller/AppointmentControllerIT.java
@@ -49,7 +49,7 @@ public class AppointmentControllerIT extends BaseIntegrationTest {
                 = deserialize(handle(newGetRequest("/rest/v1/appointment/all")),
                 new TypeReference<List<AppointmentDefaultResponse>>() {
                 });
-        assertEquals(7, asResponses.size());
+        assertEquals(9, asResponses.size());
     }
 
     @Test
@@ -103,7 +103,7 @@ public class AppointmentControllerIT extends BaseIntegrationTest {
         AppointmentsSummary appointmentsSummary = appointmentsSummaries.get(0);
         SimpleDateFormat simpleDateFormat = new SimpleDateFormat("yyyy-MM-dd");
         Date appointmentDate = simpleDateFormat.parse("2108-08-15");
-        assertEquals(2, appointmentsSummaries.size());
+        assertEquals(3, appointmentsSummaries.size());
         assertNotNull(appointmentsSummary);
         assertEquals(1, appointmentsSummary.getAppointmentService().getAppointmentServiceId(), 0);
         assertEquals("c36006e5-9fbb-4f20-866b-0ece245615a6", appointmentsSummary.getAppointmentService().getUuid());

--- a/omod/src/test/java/org/openmrs/module/appointments/web/controller/AppointmentControllerTest.java
+++ b/omod/src/test/java/org/openmrs/module/appointments/web/controller/AppointmentControllerTest.java
@@ -135,6 +135,7 @@ public class AppointmentControllerTest {
         List<Appointment> appointmentList = new ArrayList<>();
         appointmentList.add(appointment);
         List<AppointmentStatus> appointmentStatuses = Arrays.asList(
+                AppointmentStatus.Requested,
                 AppointmentStatus.Completed,
                 AppointmentStatus.Scheduled,
                 AppointmentStatus.CheckedIn,

--- a/omod/src/test/java/org/openmrs/module/appointments/web/controller/AppointmentServiceControllerIT.java
+++ b/omod/src/test/java/org/openmrs/module/appointments/web/controller/AppointmentServiceControllerIT.java
@@ -6,6 +6,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.openmrs.module.appointments.model.AppointmentServiceDefinition;
+import org.openmrs.module.appointments.model.AppointmentStatus;
 import org.openmrs.module.appointments.service.AppointmentServiceDefinitionService;
 import org.openmrs.module.appointments.service.AppointmentsService;
 import org.openmrs.module.appointments.web.BaseIntegrationTest;
@@ -131,6 +132,19 @@ public class AppointmentServiceControllerIT extends BaseIntegrationTest {
         assertEquals("type1", serviceTypes1.get("name"));
         assertEquals(20, serviceTypes1.get("duration"));
     }
+
+    @Test
+    public void should_createAppointmentServiceWithInitialAppointmentStatus() throws Exception {
+        String dataJson = "{\"name\":\"Cardiology Consultation\"," +
+                " \"initialAppointmentStatus\":\"Requested\"}";
+
+        MockHttpServletResponse handle = handle(newPostRequest("/rest/v1/appointmentService", dataJson));
+        SimpleObject asResponse = SimpleObject.parseJson(handle.getContentAsString());
+        assertNotNull(asResponse);
+        assertEquals("Cardiology Consultation", asResponse.get("name"));
+        assertEquals(AppointmentStatus.Requested.toString(), asResponse.get("initialAppointmentStatus"));
+    }
+
 
     @Test(expected = RuntimeException.class)
     public void should_notCreateAppointmentServiceWhenNameIsNull() throws Exception {

--- a/omod/src/test/java/org/openmrs/module/appointments/web/controller/AppointmentsControllerIT.java
+++ b/omod/src/test/java/org/openmrs/module/appointments/web/controller/AppointmentsControllerIT.java
@@ -323,7 +323,8 @@ public class AppointmentsControllerIT extends BaseIntegrationTest {
 
     @Test
     public void shouldChangeProviderResponse() throws Exception {
-        String content = "{\"uuid\":\"2d15071d-439d-44e8-9825-aa8e1a30d2a2\",\"response\":\"ACCEPTED\"}";
+        Context.authenticate("provider-response-user", "test");
+        String content = "{\"uuid\":\"2bdc3f7d-jh76-401a-84e9-5494dda83e8e\",\"response\":\"ACCEPTED\"}";
         MockHttpServletResponse response = handle(newPostRequest("/rest/v1/appointments/c36006e5-9fbb-4f20-8y6t-0ece245615a7/providerResponse", content));
         assertNotNull(response);
         assertEquals(200, response.getStatus());
@@ -334,7 +335,8 @@ public class AppointmentsControllerIT extends BaseIntegrationTest {
 
     @Test
     public void shouldChangeRequestedAppointmentStatusToScheduledWhenProviderAccepts() throws Exception {
-        String content = "{\"uuid\":\"2d15071d-439d-44e8-9825-aa8e1a30d2a2\",\"response\":\"ACCEPTED\"}";
+        Context.authenticate("provider-response-user", "test");
+        String content = "{\"uuid\":\"2bdc3f7d-jh76-401a-84e9-5494dda83e8e\",\"response\":\"ACCEPTED\"}";
         MockHttpServletResponse response = handle(newPostRequest("/rest/v1/appointments/c36006e5-9fbb-8ui6-8y6t-0ece245615a7/providerResponse", content));
         assertNotNull(response);
         assertEquals(200, response.getStatus());

--- a/omod/src/test/java/org/openmrs/module/appointments/web/controller/AppointmentsControllerIT.java
+++ b/omod/src/test/java/org/openmrs/module/appointments/web/controller/AppointmentsControllerIT.java
@@ -9,6 +9,7 @@ import org.openmrs.module.appointments.dao.AppointmentAuditDao;
 import org.openmrs.module.appointments.model.Appointment;
 import org.openmrs.module.appointments.model.AppointmentAudit;
 import org.openmrs.module.appointments.model.AppointmentConflictType;
+import org.openmrs.module.appointments.model.AppointmentProviderResponse;
 import org.openmrs.module.appointments.model.AppointmentStatus;
 import org.openmrs.module.appointments.service.AppointmentsService;
 import org.openmrs.module.appointments.util.DateUtil;
@@ -318,5 +319,28 @@ public class AppointmentsControllerIT extends BaseIntegrationTest {
         });
         assertEquals(1, appointmentDefaultResponse.get(AppointmentConflictType.SERVICE_UNAVAILABLE.name()).size());
         assertEquals(1, appointmentDefaultResponse.get(AppointmentConflictType.PATIENT_DOUBLE_BOOKING.name()).size());
+    }
+
+    @Test
+    public void shouldChangeProviderResponse() throws Exception {
+        String content = "{\"uuid\":\"2d15071d-439d-44e8-9825-aa8e1a30d2a2\",\"response\":\"ACCEPTED\"}";
+        MockHttpServletResponse response = handle(newPostRequest("/rest/v1/appointments/c36006e5-9fbb-4f20-8y6t-0ece245615a7/providerResponse", content));
+        assertNotNull(response);
+        assertEquals(200, response.getStatus());
+
+        Appointment appointmentByUuid = appointmentsService.getAppointmentByUuid("c36006e5-9fbb-4f20-8y6t-0ece245615a7");
+        assertEquals(AppointmentProviderResponse.ACCEPTED, appointmentByUuid.getProviders().iterator().next().getResponse());
+    }
+
+    @Test
+    public void shouldChangeRequestedAppointmentStatusToScheduledWhenProviderAccepts() throws Exception {
+        String content = "{\"uuid\":\"2d15071d-439d-44e8-9825-aa8e1a30d2a2\",\"response\":\"ACCEPTED\"}";
+        MockHttpServletResponse response = handle(newPostRequest("/rest/v1/appointments/c36006e5-9fbb-8ui6-8y6t-0ece245615a7/providerResponse", content));
+        assertNotNull(response);
+        assertEquals(200, response.getStatus());
+
+        Appointment appointmentByUuid = appointmentsService.getAppointmentByUuid("c36006e5-9fbb-8ui6-8y6t-0ece245615a7");
+        assertEquals(AppointmentStatus.Scheduled, appointmentByUuid.getStatus());
+        assertEquals(AppointmentProviderResponse.ACCEPTED, appointmentByUuid.getProviders().iterator().next().getResponse());
     }
 }

--- a/omod/src/test/java/org/openmrs/module/appointments/web/controller/AppointmentsControllerIT.java
+++ b/omod/src/test/java/org/openmrs/module/appointments/web/controller/AppointmentsControllerIT.java
@@ -1,13 +1,15 @@
 package org.openmrs.module.appointments.web.controller;
 
+import org.codehaus.jackson.map.ObjectMapper;
 import org.codehaus.jackson.type.TypeReference;
 import org.junit.Before;
 import org.junit.Test;
 import org.openmrs.api.context.Context;
-import org.openmrs.module.appointments.model.AppointmentConflictType;
 import org.openmrs.module.appointments.dao.AppointmentAuditDao;
 import org.openmrs.module.appointments.model.Appointment;
 import org.openmrs.module.appointments.model.AppointmentAudit;
+import org.openmrs.module.appointments.model.AppointmentConflictType;
+import org.openmrs.module.appointments.model.AppointmentStatus;
 import org.openmrs.module.appointments.service.AppointmentsService;
 import org.openmrs.module.appointments.util.DateUtil;
 import org.openmrs.module.appointments.web.BaseIntegrationTest;
@@ -43,6 +45,59 @@ public class AppointmentsControllerIT extends BaseIntegrationTest {
                 new TypeReference<AppointmentDefaultResponse>() {
                 });
         assertEquals("GAN200000", response.getPatient().get("identifier"));
+    }
+
+    @Test
+    public void shouldSaveNewAppointment() throws Exception {
+        String content = "{ \"providerUuid\": \"823fdcd7-3f10-11e4-adec-0800271c1b75\", " +
+                "\"appointmentNumber\": \"1\",  " +
+                "\"patientUuid\": \"2c33920f-7aa6-48d6-998a-60412d8ff7d5\", " +
+                "\"serviceUuid\": \"c36006d4-9fbb-4f20-866b-0ece245615c1\", " +
+                "\"startDateTime\": \"2017-07-20\", " +
+                "\"endDateTime\": \"2017-07-20\",  " +
+                "\"appointmentKind\": \"WalkIn\", " +
+                "\"providers\": [ {" +
+                "\"uuid\":\"2d15071d-439d-44e8-9825-aa8e1a30d2a2\"," +
+                "\"comments\":\"available\"," +
+                "\"response\":\"ACCEPTED\"" +
+                "} ] }";
+
+
+        MockHttpServletResponse response = handle(newPostRequest("/rest/v1/appointments", content));
+        assertNotNull(response);
+        assertEquals(200, response.getStatus());
+
+        String contentAsString = response.getContentAsString();
+        Map responseBody = new ObjectMapper().readValue(contentAsString, Map.class);
+        assertNotNull(responseBody.get("uuid"));
+        assertEquals(AppointmentStatus.Scheduled.name(), responseBody.get("status"));
+    }
+
+    @Test
+    public void shouldSaveNewAppointmentWithGivenStatus() throws Exception {
+        String content = "{ \"providerUuid\": \"823fdcd7-3f10-11e4-adec-0800271c1b75\", " +
+                "\"appointmentNumber\": \"1\",  " +
+                "\"status\": \"Requested\",  " +
+                "\"patientUuid\": \"2c33920f-7aa6-48d6-998a-60412d8ff7d5\", " +
+                "\"serviceUuid\": \"c36006d4-9fbb-4f20-866b-0ece245615c1\", " +
+                "\"startDateTime\": \"2017-07-20\", " +
+                "\"endDateTime\": \"2017-07-20\",  " +
+                "\"appointmentKind\": \"WalkIn\", " +
+                "\"providers\": [ {" +
+                "\"uuid\":\"2d15071d-439d-44e8-9825-aa8e1a30d2a2\"," +
+                "\"comments\":\"available\"," +
+                "\"response\":\"ACCEPTED\"" +
+                "} ] }";
+
+
+        MockHttpServletResponse response = handle(newPostRequest("/rest/v1/appointments", content));
+        assertNotNull(response);
+        assertEquals(200, response.getStatus());
+
+        String contentAsString = response.getContentAsString();
+        Map responseBody = new ObjectMapper().readValue(contentAsString, Map.class);
+        assertNotNull(responseBody.get("uuid"));
+        assertEquals(AppointmentStatus.Requested.name(), responseBody.get("status"));
     }
 
     @Test

--- a/omod/src/test/java/org/openmrs/module/appointments/web/mapper/AppointmentMapperTest.java
+++ b/omod/src/test/java/org/openmrs/module/appointments/web/mapper/AppointmentMapperTest.java
@@ -196,6 +196,35 @@ public class AppointmentMapperTest {
     }
 
     @Test
+    public void shouldCreateAppointmentWithStatusFromPayload() throws ParseException {
+        AppointmentRequest appointmentRequest = createAppointmentRequest();
+        appointmentRequest.setStatus("CheckedIn");
+
+        String appointmentUuid = "7869637c-12fe-4121-9692-b01f93f99e55";
+        Appointment existingAppointment = createAppointment();
+        existingAppointment.setUuid(appointmentUuid);
+        existingAppointment.setStatus(AppointmentStatus.CheckedIn);
+        when(appointmentsService.getAppointmentByUuid(appointmentUuid)).thenReturn(existingAppointment);
+
+        Appointment appointment = appointmentMapper.fromRequest(appointmentRequest);
+        assertNotNull(appointment);
+        assertEquals(AppointmentStatus.CheckedIn, appointment.getStatus());
+        assertEquals(appointmentRequest.getComments(), appointment.getComments());
+
+    }
+
+    @Test
+    public void shouldMapExistingAppointmentWhenPayloadHasAppointmentStatus() throws ParseException {
+        AppointmentRequest appointmentRequest = createAppointmentRequest();
+        appointmentRequest.setStatus("Requested");
+        Appointment appointment = appointmentMapper.fromRequest(appointmentRequest);
+        assertNotNull(appointment);
+        assertEquals(AppointmentStatus.Requested, appointment.getStatus());
+        assertEquals(appointmentRequest.getComments(), appointment.getComments());
+
+    }
+
+    @Test
     public void shouldGetExistingAppointmentBookedAgainstVoidedServiceTypeFromPayload() throws Exception {
         String appointmentUuid = "7869637c-12fe-4121-9692-b01f93f99e55";
         Appointment existingAppointment = createAppointment();

--- a/omod/src/test/resources/appointmentTestData.xml
+++ b/omod/src/test/resources/appointmentTestData.xml
@@ -71,14 +71,33 @@
                         preferred="1" location_id="1" creator="1" date_created="2005-01-01 00:00:00.0" voided="false"
                         uuid="0b7cf2fa-b377-455c-jh76-231cf34a21ac"/>
 
+<!--    Change Provider Response Dataset-->
+    <person person_id="11" gender="M" dead="false" creator="1" birthdate_estimated="0" date_created="2008-08-15 15:57:09.0" voided="false" void_reason="" uuid="2c33920f-34dr-48d6-998a-60412d8ff7d5"/>r
+    <users user_id="11" person_id="11" system_id="11-6" username="provider-response-user" retired="false"
+           password="4a1750c8607d0fa237de36c6305715c223415189" salt="c788c6ad82a157b712392ca695dfcf2eed193d7f"
+           secret_question="" creator="1" date_created="2008-08-15 15:46:47.0"
+           uuid="Z9fd3a7b-6482-kj45-87eR-c07b123MxF99"/>
+
+    <privilege privilege="View Appointments" description="Able to view Appointments in Appointments module"/>
+    <privilege privilege="Manage Own Appointments" description="Able to manage own Appointments in Appointments module"/>
+    <privilege privilege="Get Providers" description="Able to view Providers"/>
+    <role role="Provider Response Update" description="To Test Provider response update" uuid="3480cb6d-c551-46c8-8d3a-96dc33d109fb"/>
+    <role_privilege role="Provider Response Update" privilege="View Appointments"/>
+    <role_privilege role="Provider Response Update" privilege="Manage Own Appointments"/>
+    <role_privilege role="Provider Response Update" privilege="Get Providers"/>
+
+    <user_role user_id="11" role="Provider Response Update"/>
+    <provider provider_id="2222" person_id="11" name="provider-response-user" creator="1" date_created="2005-01-01 00:00:00.0" retired="false" uuid="2bdc3f7d-jh76-401a-84e9-5494dda83e8e" />
+
     <appointment_service appointment_service_id="4" name="Ortho" description="Ortho" start_time="11:00:00" end_time="15:00:00" location_id="1" uuid="c36006d4-9fbb-ki98-866b-0ece245615c1"
                          speciality_id="1" max_appointments_limit="7" duration_mins="16" creator="1" voided="false"/>
 
     <patient_appointment patient_appointment_id="9" patient_id ="2" appointment_service_id="4" start_date_time="2107-07-15 17:00:00.0" end_date_time="2107-07-15 18:00:00.0" appointment_kind="Scheduled" status="Scheduled" creator="1" date_created="2108-08-10 15:57:09.0" voided="false" void_reason="" uuid="c36006e5-9fbb-4f20-8y6t-0ece245615a7"/>
-    <patient_appointment_provider patient_appointment_provider_id="1" patient_appointment_id="9" provider_id="2221" response="AWAITING" creator="1"
+    <patient_appointment_provider patient_appointment_provider_id="1" patient_appointment_id="9" provider_id="2222" response="AWAITING" creator="1"
                                   date_created="2005-01-01 00:00:00.0"  uuid="2d15071d-439d-44e8-8yu6-aa8e1a30d2a2"/>
 
     <patient_appointment patient_appointment_id="10" patient_id ="2" appointment_service_id="4" start_date_time="2107-07-15 17:00:00.0" end_date_time="2107-07-15 18:00:00.0" appointment_kind="Scheduled" status="Requested" creator="1" date_created="2108-08-10 15:57:09.0" voided="false" void_reason="" uuid="c36006e5-9fbb-8ui6-8y6t-0ece245615a7"/>
-    <patient_appointment_provider patient_appointment_provider_id="2" patient_appointment_id="10" provider_id="2221" response="AWAITING" creator="1"
+    <patient_appointment_provider patient_appointment_provider_id="2" patient_appointment_id="10" provider_id="2222" response="AWAITING" creator="1"
                                   date_created="2005-01-01 00:00:00.0"  uuid="2d15071d-67fr-44e8-8yu6-aa8e1a30d2a2"/>
+<!--    Change Provider Response Dataset-->
 </dataset>

--- a/omod/src/test/resources/appointmentTestData.xml
+++ b/omod/src/test/resources/appointmentTestData.xml
@@ -65,5 +65,20 @@
     <provider provider_id="2221" person_id="221" name="labtechnician" identifier="labtechnician" creator="1"
               date_created="2005-01-01 00:00:00.0"  retired="false" uuid="2d15071d-439d-44e8-9825-aa8e1a30d2a2"/>
 
+    <person person_id="2" gender="M" dead="false" creator="1" birthdate_estimated="0" date_created="2008-08-15 15:57:09.0" voided="false" void_reason="" uuid="2c33920f-7aa6-uhy5-998a-60412d8ff7d5"/>r
+    <patient patient_id="2" creator="1" date_created="2008-08-15 15:57:09.0" voided="false" void_reason=""/>
+    <patient_identifier patient_identifier_id="2" patient_id="2" identifier="GAN200001" identifier_type="1"
+                        preferred="1" location_id="1" creator="1" date_created="2005-01-01 00:00:00.0" voided="false"
+                        uuid="0b7cf2fa-b377-455c-jh76-231cf34a21ac"/>
 
+    <appointment_service appointment_service_id="4" name="Ortho" description="Ortho" start_time="11:00:00" end_time="15:00:00" location_id="1" uuid="c36006d4-9fbb-ki98-866b-0ece245615c1"
+                         speciality_id="1" max_appointments_limit="7" duration_mins="16" creator="1" voided="false"/>
+
+    <patient_appointment patient_appointment_id="9" patient_id ="2" appointment_service_id="4" start_date_time="2107-07-15 17:00:00.0" end_date_time="2107-07-15 18:00:00.0" appointment_kind="Scheduled" status="Scheduled" creator="1" date_created="2108-08-10 15:57:09.0" voided="false" void_reason="" uuid="c36006e5-9fbb-4f20-8y6t-0ece245615a7"/>
+    <patient_appointment_provider patient_appointment_provider_id="1" patient_appointment_id="9" provider_id="2221" response="AWAITING" creator="1"
+                                  date_created="2005-01-01 00:00:00.0"  uuid="2d15071d-439d-44e8-8yu6-aa8e1a30d2a2"/>
+
+    <patient_appointment patient_appointment_id="10" patient_id ="2" appointment_service_id="4" start_date_time="2107-07-15 17:00:00.0" end_date_time="2107-07-15 18:00:00.0" appointment_kind="Scheduled" status="Requested" creator="1" date_created="2108-08-10 15:57:09.0" voided="false" void_reason="" uuid="c36006e5-9fbb-8ui6-8y6t-0ece245615a7"/>
+    <patient_appointment_provider patient_appointment_provider_id="2" patient_appointment_id="10" provider_id="2221" response="AWAITING" creator="1"
+                                  date_created="2005-01-01 00:00:00.0"  uuid="2d15071d-67fr-44e8-8yu6-aa8e1a30d2a2"/>
 </dataset>


### PR DESCRIPTION
- [x] Introduce a new field `Initial Appointment Status` as part of service definition.
- [x] Introduce a new `AppointmentStatus` named `Requested`.
- [x] Introduce `changeProviderResponse Endpoint (/providerResponse) in `AppointmentsController`.
- [x] Provide implementation for `changeProviderResponse` in AppointmentService.

Epic Card: https://bahmni.atlassian.net/browse/AP-36