### PR TITLE
#26 Typo in Advice definition

### DIFF
--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -44,7 +44,7 @@
 	<!-- /Internationalization -->
 
 	<advice>
-		<point>org.openmrs.module.appointments.service.AppointmentServiceService</point>
+		<point>org.openmrs.module.appointments.service.AppointmentService</point>
 		<class>org.openmrs.module.appointments.advice.AppointmentServiceDefinitionAdvice</class>
 	</advice>
 


### PR DESCRIPTION
See: https://github.com/Bahmni/openmrs-module-appointments/issues/26

Replace `AppointmentServiceService` by `AppointmentService`