### PR TITLE
Run gpg only for deployment

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -368,7 +368,7 @@
 						<executions>
 							<execution>
 								<id>sign-artifacts</id>
-								<phase>verify</phase>
+								<phase>deploy</phase>
 								<goals>
 									<goal>sign</goal>
 								</goals>


### PR DESCRIPTION
This PR will move the gpg plugin from `verify phase` to `deploy phase` so it doesn't require to sign artifact while running `mvn clean install`