### PR TITLE
Fix activator in config; Move gpg,java-doc and sources in different profile.

### DIFF
--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -9,7 +9,7 @@
 	<package>${MODULE_PACKAGE}</package>
 	<description>${project.parent.description}</description>
 
-	<activator>${MODULE_PACKAGE}.AppointmentsActivator</activator>
+	<activator>org.openmrs.module.appointments.AppointmentsActivator</activator>
 
 	<require_modules>
 		<require_module>org.openmrs.module.webservices.rest</require_module>

--- a/pom.xml
+++ b/pom.xml
@@ -337,6 +337,19 @@
 							</execution>
 						</executions>
 					</plugin>
+				</plugins>
+			</build>
+		</profile>
+		<profile>
+			<id>release-sign-artifacts</id>
+			<activation>
+				<property>
+					<name>performRelease</name>
+					<value>true</value>
+				</property>
+			</activation>
+			<build>
+				<plugins>
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-source-plugin</artifactId>
@@ -368,7 +381,7 @@
 						<executions>
 							<execution>
 								<id>sign-artifacts</id>
-								<phase>deploy</phase>
+								<phase>verify</phase>
 								<goals>
 									<goal>sign</goal>
 								</goals>


### PR DESCRIPTION
The following changes are done as part of this PR:
- [x] Hardcode the activator package path to be `org.openmrs.module`
- [x] The `mvn-gpg-plugin`, `mvn-javadoc-plugin`, `mvn-sources-plugin` has been moved to a profile `performRelease`. These will not be invoked unless `-DperformRelease=true` is passed. This is to ensure  `mvn clean install` runs as it is.