### PR TITLE
AP-76: Defining beans through Spring application context XML.

### DIFF
--- a/api/src/main/java/org/openmrs/module/appointments/helper/AppointmentServiceHelper.java
+++ b/api/src/main/java/org/openmrs/module/appointments/helper/AppointmentServiceHelper.java
@@ -18,7 +18,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
-@Component
 public class AppointmentServiceHelper {
 
     public void checkAndAssignAppointmentNumber(Appointment appointment) {

--- a/api/src/main/java/org/openmrs/module/appointments/service/impl/TeleconsultationAppointmentSavedEventListener.java
+++ b/api/src/main/java/org/openmrs/module/appointments/service/impl/TeleconsultationAppointmentSavedEventListener.java
@@ -9,7 +9,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationListener;
 import org.springframework.stereotype.Component;
 
-@Component
 public class TeleconsultationAppointmentSavedEventListener implements ApplicationListener<TeleconsultationAppointmentSavedEvent> {
 
     private Log log = LogFactory.getLog(this.getClass());
@@ -31,5 +30,13 @@ public class TeleconsultationAppointmentSavedEventListener implements Applicatio
             event.getAppointment().setEmailSent(false);
             log.error("Unable to send teleconsultation appointment email notification", e);
         }
+    }
+
+    public TeleconsultationAppointmentNotificationService getEmailNotificationService() {
+        return emailNotificationService;
+    }
+
+    public void setEmailNotificationService(TeleconsultationAppointmentNotificationService emailNotificationService) {
+        this.emailNotificationService = emailNotificationService;
     }
 }

--- a/api/src/main/java/org/openmrs/module/appointments/validator/impl/DefaultAppointmentStatusChangeValidator.java
+++ b/api/src/main/java/org/openmrs/module/appointments/validator/impl/DefaultAppointmentStatusChangeValidator.java
@@ -8,7 +8,6 @@ import org.springframework.stereotype.Component;
 
 import java.util.List;
 
-@Component
 public class DefaultAppointmentStatusChangeValidator implements AppointmentStatusChangeValidator {
 
     @Override

--- a/api/src/main/java/org/openmrs/module/appointments/validator/impl/DefaultAppointmentValidator.java
+++ b/api/src/main/java/org/openmrs/module/appointments/validator/impl/DefaultAppointmentValidator.java
@@ -7,7 +7,6 @@ import org.springframework.stereotype.Component;
 
 import java.util.List;
 
-@Component
 public class DefaultAppointmentValidator implements AppointmentValidator {
 
 	@Override

--- a/api/src/main/resources/moduleApplicationContext.xml
+++ b/api/src/main/resources/moduleApplicationContext.xml
@@ -23,6 +23,17 @@
   		    http://www.springframework.org/schema/util
   		    http://www.springframework.org/schema/util/spring-util-3.0.xsd http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc.xsd">
     <context:component-scan base-package="org.openmrs.module.appointments"/>
+
+    <bean id="appointmentServiceHelper" class="org.openmrs.module.appointments.helper.AppointmentServiceHelper"/>
+    <bean id="teleconsultationAppointmentSavedEventListener" class="org.openmrs.module.appointments.service.impl.TeleconsultationAppointmentSavedEventListener">
+        <property name="emailNotificationService">
+            <ref bean="teleconsultationAppointmentNotificationService"/>
+        </property>
+    </bean>
+
+    <bean id="defaultAppointmentStatusChangeValidator" class="org.openmrs.module.appointments.validator.impl.DefaultAppointmentStatusChangeValidator"/>
+    <bean id="defaultAppointmentValidator" class="org.openmrs.module.appointments.validator.impl.DefaultAppointmentValidator"/>
+
     <bean id="administrationService" name="administrationService" class="org.openmrs.api.impl.AdministrationServiceImpl"/>
     <bean parent="serviceContext">
         <property name="moduleService">

--- a/omod/src/main/resources/webModuleApplicationContext.xml
+++ b/omod/src/main/resources/webModuleApplicationContext.xml
@@ -22,9 +22,6 @@
 
 	<!-- Add here beans related to the web context -->
 
-	 
-	<!-- Annotation based controllers -->
-	<bean class="org.springframework.web.servlet.mvc.annotation.DefaultAnnotationHandlerMapping"/>
 	<context:component-scan base-package="org.openmrs.module.appointments" />
 
 </beans>


### PR DESCRIPTION
Issue: https://bahmni.atlassian.net/browse/AP-76

There seems to be 2 different problems:

First one is a standard problem related to org.springframework.web.servlet.mvc.annotation.DefaultAnnotationHandlerMapping
For more information "https://talk.openmrs.org/t/platform-2-4-release-to-dos-and-release-discussions-thread/30616/70?u=mksd"

Second one has to due with bean creation
There are a couple of beans that are being created multiple times, resulting in conflicts.
The Beans in question are:
 - AppointmentServiceHelper
 - TeleconsultationAppointmentSavedEventListener
 - DefaultAppointmentStatusChangeValidator
 - DefaultAppointmentValidator

Solution: 
  First problem:
  The following piece of code was removed, since it no longer is required.
  org.springframework.web.servlet.mvc.annotation.DefaultAnnotationHandlerMapping
  
  Second problem:
  Changed the Beans from being created with annotations, to being created with a xml file 
  Affected Beans:
   - AppointmentServiceHelper
   - TeleconsultationAppointmentSavedEventListener
   - DefaultAppointmentStatusChangeValidator
   - DefaultAppointmentValidator
