### PR TITLE
BAH-1209: Fetch appointments for non-voided patients only.

### DIFF
--- a/api/src/main/java/org/openmrs/module/appointments/dao/impl/AppointmentDaoImpl.java
+++ b/api/src/main/java/org/openmrs/module/appointments/dao/impl/AppointmentDaoImpl.java
@@ -34,6 +34,8 @@ public class AppointmentDaoImpl implements AppointmentDao {
     public List<Appointment> getAllAppointments(Date forDate) {
         Criteria criteria = sessionFactory.getCurrentSession().createCriteria(Appointment.class);
         criteria.add(Restrictions.eq("voided", false));
+        criteria.createAlias("patient", "patient");
+        criteria.add(Restrictions.eq("patient.voided", false));
         if (forDate != null) {
             Date maxDate = new Date(forDate.getTime() + TimeUnit.DAYS.toMillis(1));
             criteria.add(Restrictions.ge("startDateTime", forDate));
@@ -74,6 +76,8 @@ public class AppointmentDaoImpl implements AppointmentDao {
         criteria.add(Restrictions.eq("service", appointmentServiceDefinition));
         criteria.add(Restrictions.gt("endDateTime", new Date()));
         criteria.add(Restrictions.eq("voided", false));
+        criteria.createAlias("patient", "patient");
+        criteria.add(Restrictions.eq("patient.voided", false));
         criteria.add(Restrictions.ne("status", AppointmentStatus.Cancelled));
         return criteria.list();
     }
@@ -84,6 +88,8 @@ public class AppointmentDaoImpl implements AppointmentDao {
         criteria.add(Restrictions.eq("serviceType", appointmentServiceType));
         criteria.add(Restrictions.gt("endDateTime", new Date()));
         criteria.add(Restrictions.eq("voided", false));
+        criteria.createAlias("patient", "patient");
+        criteria.add(Restrictions.eq("patient.voided", false));
         criteria.add(Restrictions.ne("status", AppointmentStatus.Cancelled));
         return criteria.list();
     }
@@ -94,6 +100,8 @@ public class AppointmentDaoImpl implements AppointmentDao {
         criteria.createAlias("serviceType", "serviceType", JoinType.LEFT_OUTER_JOIN);
         criteria.add(Restrictions.or(Restrictions.isNull("serviceType"), Restrictions.eq("serviceType.voided", false)));
         criteria.add(Restrictions.eq("voided", false));
+        criteria.createAlias("patient", "patient");
+        criteria.add(Restrictions.eq("patient.voided", false));
         criteria.add(Restrictions.ge("startDateTime", startDate));
         criteria.add(Restrictions.le("startDateTime", endDate));
         criteria.createCriteria("service").add(Example.create(appointmentServiceDefinition));
@@ -115,6 +123,8 @@ public class AppointmentDaoImpl implements AppointmentDao {
     public List<Appointment> getAllAppointmentsInDateRange(Date startDate, Date endDate) {
         Criteria criteria = sessionFactory.getCurrentSession().createCriteria(Appointment.class);
         criteria.add(Restrictions.eq("voided", false));
+        criteria.createAlias("patient", "patient");
+        criteria.add(Restrictions.eq("patient.voided", false));
         if (startDate != null) {
             criteria.add(Restrictions.ge("startDateTime", startDate));
         }
@@ -147,8 +157,9 @@ public class AppointmentDaoImpl implements AppointmentDao {
     }
 
     private void setPatientCriteria(AppointmentSearchRequest appointmentSearchRequest, Criteria criteria) {
+        criteria.createAlias("patient", "patient");
+        criteria.add(Restrictions.eq("patient.voided", false));
         if (StringUtils.isNotEmpty(appointmentSearchRequest.getPatientUuid())) {
-            criteria.createAlias("patient", "patient");
             criteria.add(Restrictions.eq("patient.uuid", appointmentSearchRequest.getPatientUuid()));
         }
     }
@@ -177,6 +188,7 @@ public class AppointmentDaoImpl implements AppointmentDao {
         criteria.createAlias("patient", "patient");
         criteria.add(Restrictions.eq("patient.patientId", patientId));
         criteria.add(Restrictions.eq("voided", false));
+        criteria.add(Restrictions.eq("patient.voided", false));
         criteria.add(Restrictions.ge("startDateTime", DateUtil.getStartOfDay()));
 
         return criteria.list();

--- a/api/src/test/resources/appointmentTestData.xml
+++ b/api/src/test/resources/appointmentTestData.xml
@@ -97,4 +97,10 @@
                          end_date_time="2108-08-08 14:00:00.0" status="Scheduled" creator="1" date_created="2108-07-11 15:57:09.0"
                          voided="false" void_reason="" uuid="c36006e5-9fbb-4f20-866b-0ece236715a8"/>
 
+    <!-- Appointment for voided patient-->
+    <person person_id="4" gender="M" dead="false" creator="1" birthdate_estimated="0" date_created="2008-08-01 20:20:10.0" voided="true" void_reason="Test void reason" uuid="5e27e922-67c3-43b2-82cd-4a0d66763655"/>
+    <patient patient_id="3" creator="1" date_created="2008-08-15 11:10:35.0" voided="true" void_reason=""/>
+    <patient_identifier patient_identifier_id="2" patient_id="2" identifier="GAN300000" identifier_type="1" preferred="1" location_id="1" creator="1" date_created="2006-01-01 00:00:00.0" voided="false" uuid="35f46473-9ed1-4812-8f3a-4740c13dc54f"/>
+    <patient_appointment patient_appointment_id="16" patient_id ="3" appointment_service_id="1" appointment_service_type_id="2" start_date_time="2017-08-08 14:00:00.0" end_date_time="2017-08-10 15:00:00.0" status="Scheduled" creator="1" date_created="2108-08-10 15:57:09.0" voided="false" void_reason="" uuid="aeead7f2-fc3d-48bb-9c63-e861aaea4a9c"/>
+
 </dataset>

--- a/pom.xml
+++ b/pom.xml
@@ -265,7 +265,7 @@
 			<repository>
 				<id>openmrs-repo</id>
 				<name>OpenMRS Nexus Repository</name>
-				<url>http://mavenrepo.openmrs.org/nexus/content/repositories/public</url>
+				<url>https://mavenrepo.openmrs.org/nexus/content/repositories/public</url>
 			</repository>
 			<repository>
 				<id>sonatype-nexus-snapshots</id>
@@ -296,7 +296,7 @@
 		<pluginRepository>
 			<id>openmrs-repo</id>
 			<name>OpenMRS Nexus Repository</name>
-			<url>http://mavenrepo.openmrs.org/nexus/content/repositories/public</url>
+			<url>https://mavenrepo.openmrs.org/nexus/content/repositories/public</url>
 			<snapshots>
 				<enabled>false</enabled>
 			</snapshots>


### PR DESCRIPTION
#### Ticket:
https://bahmni.atlassian.net/browse/AP-78
#### What I have done:
Just adding a voided patient in **api/src/test/resources/appointmentTestData.xml** makes a bunch of test fails because the code does not cater for this situation.
I adapted `AppointmentDaoImpl` to clear this issue away.