### PR TITLE
AP-77: Changed characters escaping in Liquibase SQL files.

### DIFF
--- a/api/src/main/resources/liquibase.xml
+++ b/api/src/main/resources/liquibase.xml
@@ -339,7 +339,7 @@
         </sql>
     </changeSet>
 
-    <changeSet id="global-property-past-appointments-sql-09022021" author="Maharjun, Shireesha">
+    <changeSet id="global-property-past-appointments-sql-09022021" author="Maharjun, Shireesha" runOnChange="true">
         <preConditions onFail="MARK_RAN">
             <sqlCheck expectedResult="0">select count(*) from global_property where property='bahmni.sqlGet.pastAppointments'</sqlCheck>
         </preConditions>
@@ -347,7 +347,7 @@
         <sqlFile path="patientPastAppointments.sql"/>
     </changeSet>
 
-    <changeSet id="global-property-past-appointments-sql-update" author="Himabindu">
+    <changeSet id="global-property-past-appointments-sql-update" author="Himabindu" runOnChange="true">
         <preConditions onFail="MARK_RAN">
             <sqlCheck expectedResult="1">select count(*) from global_property where property='bahmni.sqlGet.pastAppointments'</sqlCheck>
         </preConditions>
@@ -355,7 +355,7 @@
         <sqlFile path="patientPastAppointments_v2.sql"/>
     </changeSet>
 
-    <changeSet id="global-property-upcoming-appointments-sql-09022021" author="Maharjun, Shireesha">
+    <changeSet id="global-property-upcoming-appointments-sql-09022021" author="Maharjun, Shireesha" runOnChange="true">
         <preConditions onFail="MARK_RAN">
             <sqlCheck expectedResult="0">select count(*) from global_property where property='bahmni.sqlGet.upComingAppointments'</sqlCheck>
         </preConditions>
@@ -363,7 +363,7 @@
         <sqlFile path="patientUpcomingAppointments.sql"/>
     </changeSet>
 
-    <changeSet id="global-property-upcoming-appointments-sql-update" author="Shankar, Mahesh">
+    <changeSet id="global-property-upcoming-appointments-sql-update" author="Shankar, Mahesh" runOnChange="true">
         <preConditions onFail="MARK_RAN">
             <sqlCheck expectedResult="1">select count(*) from global_property where property='bahmni.sqlGet.upComingAppointments'</sqlCheck>
         </preConditions>

--- a/api/src/main/resources/patientPastAppointments.sql
+++ b/api/src/main/resources/patientPastAppointments.sql
@@ -1,10 +1,9 @@
 INSERT INTO global_property (property, property_value, description, uuid)
- VALUES ('bahmni.sqlGet.pastAppointments',
-"SELECT
+VALUES ('bahmni.sqlGet.pastAppointments','SELECT
      app_service.name                                                                                AS `DASHBOARD_APPOINTMENTS_SERVICE_KEY`,
      app_service_type.name                                                                           AS `DASHBOARD_APPOINTMENTS_SERVICE_TYPE_KEY`,
-     DATE_FORMAT(start_date_time, \"%d/%m/%Y\")                                                        AS `DASHBOARD_APPOINTMENTS_DATE_KEY`,
-     CONCAT(DATE_FORMAT(start_date_time, \"%l:%i %p\"), \" - \", DATE_FORMAT(end_date_time, \"%l:%i %p\")) AS `DASHBOARD_APPOINTMENTS_SLOT_KEY`,
+     DATE_FORMAT(start_date_time, "%d/%m/%Y")                                                        AS `DASHBOARD_APPOINTMENTS_DATE_KEY`,
+     CONCAT(DATE_FORMAT(start_date_time, "%l:%i %p"), " - ", DATE_FORMAT(end_date_time, "%l:%i %p")) AS `DASHBOARD_APPOINTMENTS_SLOT_KEY`,
      CONCAT(pn.given_name, ' ', pn.family_name)                                                      AS `DASHBOARD_APPOINTMENTS_PROVIDER_KEY`,
      pa.status                                                                                       AS `DASHBOARD_APPOINTMENTS_STATUS_KEY`
 FROM
@@ -18,5 +17,5 @@ FROM
      ON app_service_type.appointment_service_type_id = pa.appointment_service_type_id
  WHERE p.uuid = ${patientUuid} AND start_date_time < CURDATE() AND (app_service_type.voided IS FALSE OR app_service_type.voided IS NULL)
  ORDER BY start_date_time DESC
- LIMIT 5;"
+ LIMIT 5;'
 , 'Past appointments for patient', uuid());

--- a/api/src/main/resources/patientPastAppointments.sql
+++ b/api/src/main/resources/patientPastAppointments.sql
@@ -11,6 +11,7 @@ FROM
    JOIN person p ON p.person_id = pa.patient_id AND pa.voided IS FALSE
    JOIN appointment_service app_service
      ON app_service.appointment_service_id = pa.appointment_service_id AND app_service.voided IS FALSE
+   LEFT JOIN patient_appointment_provider pap on pa.patient_appointment_id = pap.patient_appointment_id AND (pap.voided=0 OR pap.voided IS NULL)
    LEFT JOIN provider prov ON prov.provider_id = pap.provider_id AND prov.retired IS FALSE
    LEFT JOIN person_name pn ON pn.person_id = prov.person_id AND pn.voided IS FALSE
    LEFT JOIN appointment_service_type app_service_type

--- a/api/src/main/resources/patientPastAppointments_v2.sql
+++ b/api/src/main/resources/patientPastAppointments_v2.sql
@@ -1,22 +1,22 @@
 UPDATE global_property
-SET property_value= "SELECT
+SET property_value= 'SELECT
      app_service.name                                                                                AS `DASHBOARD_APPOINTMENTS_SERVICE_KEY`,
      app_service_type.name                                                                           AS `DASHBOARD_APPOINTMENTS_SERVICE_TYPE_KEY`,
-     DATE_FORMAT(start_date_time, \"%d/%m/%Y\")                                                        AS `DASHBOARD_APPOINTMENTS_DATE_KEY`,
-     CONCAT(DATE_FORMAT(start_date_time, \"%l:%i %p\"), \" - \", DATE_FORMAT(end_date_time, \"%l:%i %p\")) AS `DASHBOARD_APPOINTMENTS_SLOT_KEY`,
+     DATE_FORMAT(start_date_time, "%d/%m/%Y")                                                        AS `DASHBOARD_APPOINTMENTS_DATE_KEY`,
+     CONCAT(DATE_FORMAT(start_date_time, "%l:%i %p"), " - ", DATE_FORMAT(end_date_time, "%l:%i %p")) AS `DASHBOARD_APPOINTMENTS_SLOT_KEY`,
      CONCAT(pn.given_name, ' ', pn.family_name)                                                      AS `DASHBOARD_APPOINTMENTS_PROVIDER_KEY`,
      pa.status                                                                                       AS `DASHBOARD_APPOINTMENTS_STATUS_KEY`
 FROM
-   patient_appointment pa
-   JOIN person p ON p.person_id = pa.patient_id AND pa.voided IS FALSE
-   JOIN appointment_service app_service
-     ON app_service.appointment_service_id = pa.appointment_service_id AND app_service.voided IS FALSE
-   LEFT JOIN patient_appointment_provider pap on pa.patient_appointment_id = pap.patient_appointment_id AND (pap.voided=0 OR pap.voided IS NULL)
-   LEFT JOIN provider prov ON prov.provider_id = pap.provider_id AND prov.retired IS FALSE
-   LEFT JOIN person_name pn ON pn.person_id = prov.person_id AND pn.voided IS FALSE
-   LEFT JOIN appointment_service_type app_service_type
-     ON app_service_type.appointment_service_type_id = pa.appointment_service_type_id
- WHERE p.uuid = ${patientUuid} AND start_date_time < CURDATE() AND (app_service_type.voided IS FALSE OR app_service_type.voided IS NULL)
- ORDER BY start_date_time DESC
- LIMIT 5;"
- WHERE property='bahmni.sqlGet.pastAppointments'
+patient_appointment pa
+JOIN person p ON p.person_id = pa.patient_id AND pa.voided IS FALSE
+JOIN appointment_service app_service
+ ON app_service.appointment_service_id = pa.appointment_service_id AND app_service.voided IS FALSE
+LEFT JOIN patient_appointment_provider pap on pa.patient_appointment_id = pap.patient_appointment_id AND (pap.voided=0 OR pap.voided IS NULL)
+LEFT JOIN provider prov ON prov.provider_id = pap.provider_id AND prov.retired IS FALSE
+LEFT JOIN person_name pn ON pn.person_id = prov.person_id AND pn.voided IS FALSE
+LEFT JOIN appointment_service_type app_service_type
+ ON app_service_type.appointment_service_type_id = pa.appointment_service_type_id
+WHERE p.uuid = ${patientUuid} AND start_date_time < CURDATE() AND (app_service_type.voided IS FALSE OR app_service_type.voided IS NULL)
+ORDER BY start_date_time DESC
+LIMIT 5;'
+WHERE property = 'bahmni.sqlGet.pastAppointments';

--- a/api/src/main/resources/patientUpcomingAppointments.sql
+++ b/api/src/main/resources/patientUpcomingAppointments.sql
@@ -1,11 +1,11 @@
 INSERT INTO global_property (property, property_value, description, uuid)
- VALUES ('bahmni.sqlGet.upComingAppointments',
-"SELECT
-  app_service.name                                                                                AS `DASHBOARD_APPOINTMENTS_SERVICE_KEY`,
-  app_service_type.name                                                                           AS `DASHBOARD_APPOINTMENTS_SERVICE_TYPE_KEY`,
-  DATE_FORMAT(start_date_time, \"%d/%m/%Y\")                                                        AS `DASHBOARD_APPOINTMENTS_DATE_KEY`,
-  CONCAT(DATE_FORMAT(start_date_time, \"%l:%i %p\"), \" - \", DATE_FORMAT(end_date_time, \"%l:%i %p\")) AS `DASHBOARD_APPOINTMENTS_SLOT_KEY`,
-  CONCAT(pn.given_name, ' ', pn.family_name)                                                      AS `DASHBOARD_APPOINTMENTS_PROVIDER_KEY`,
+VALUES ('bahmni.sqlGet.upComingAppointments',
+        'SELECT
+          app_service.name                                                                                AS `DASHBOARD_APPOINTMENTS_SERVICE_KEY`,
+          app_service_type.name                                                                           AS `DASHBOARD_APPOINTMENTS_SERVICE_TYPE_KEY`,
+          DATE_FORMAT(start_date_time, "%d/%m/%Y")                                                        AS `DASHBOARD_APPOINTMENTS_DATE_KEY`,
+          CONCAT(DATE_FORMAT(start_date_time, "%l:%i %p"), " - ", DATE_FORMAT(end_date_time, "%l:%i %p")) AS `DASHBOARD_APPOINTMENTS_SLOT_KEY`,
+          CONCAT(pn.given_name, ' ', pn.family_name)                                                      AS `DASHBOARD_APPOINTMENTS_PROVIDER_KEY`,
   pa.status                                                                                       AS `DASHBOARD_APPOINTMENTS_STATUS_KEY`
 FROM
   patient_appointment pa
@@ -19,5 +19,5 @@ FROM
 WHERE p.uuid = ${patientUuid} AND
       start_date_time >= CURDATE() AND
       (app_service_type.voided IS FALSE OR app_service_type.voided IS NULL)
-ORDER BY start_date_time ASC;"
+ORDER BY start_date_time ASC;'
 , 'Upcoming appointments for patient', uuid());

--- a/api/src/main/resources/patientUpcomingAppointments.sql
+++ b/api/src/main/resources/patientUpcomingAppointments.sql
@@ -12,6 +12,7 @@ FROM
   JOIN person p ON p.person_id = pa.patient_id AND pa.voided IS FALSE
   JOIN appointment_service app_service
     ON app_service.appointment_service_id = pa.appointment_service_id AND app_service.voided IS FALSE
+  LEFT JOIN patient_appointment_provider pap on pa.patient_appointment_id = pap.patient_appointment_id AND (pap.voided=0 OR pap.voided IS NULL)
   LEFT JOIN provider prov ON prov.provider_id = pap.provider_id AND prov.retired IS FALSE
   LEFT JOIN person_name pn ON pn.person_id = prov.person_id AND pn.voided IS FALSE
   LEFT JOIN appointment_service_type app_service_type

--- a/api/src/main/resources/patientUpcomingAppointments_v2.sql
+++ b/api/src/main/resources/patientUpcomingAppointments_v2.sql
@@ -1,10 +1,10 @@
 UPDATE global_property
-SET property_value= "SELECT
+SET property_value= 'SELECT
   pa.uuid,
   app_service.name                                                                                AS `DASHBOARD_APPOINTMENTS_SERVICE_KEY`,
   app_service_type.name                                                                           AS `DASHBOARD_APPOINTMENTS_SERVICE_TYPE_KEY`,
-  DATE_FORMAT(start_date_time, \"%d/%m/%Y\")                                                        AS `DASHBOARD_APPOINTMENTS_DATE_KEY`,
-  CONCAT(DATE_FORMAT(start_date_time, \"%l:%i %p\"), \" - \", DATE_FORMAT(end_date_time, \"%l:%i %p\")) AS `DASHBOARD_APPOINTMENTS_SLOT_KEY`,
+  DATE_FORMAT(start_date_time, "%d/%m/%Y")                                                        AS `DASHBOARD_APPOINTMENTS_DATE_KEY`,
+  CONCAT(DATE_FORMAT(start_date_time, "%l:%i %p"), " - ", DATE_FORMAT(end_date_time, "%l:%i %p")) AS `DASHBOARD_APPOINTMENTS_SLOT_KEY`,
   CONCAT(pn.given_name, ' ', pn.family_name)                                                      AS `DASHBOARD_APPOINTMENTS_PROVIDER_KEY`,
   pa.status                                                                                       AS `DASHBOARD_APPOINTMENTS_STATUS_KEY`,
   pa.teleconsultation                                                                             AS `DASHBOARD_APPOINTMENTS_TELECONSULTATION`,
@@ -24,5 +24,5 @@ FROM
 WHERE p.uuid = ${patientUuid} AND
       start_date_time >= CURDATE() AND
       (app_service_type.voided IS FALSE OR app_service_type.voided IS NULL)
-ORDER BY start_date_time ASC;"
-WHERE property='bahmni.sqlGet.upComingAppointments'
+ORDER BY start_date_time ASC;'
+WHERE property='bahmni.sqlGet.upComingAppointments';


### PR DESCRIPTION
Note:  Some files contained an error in the SQL (patientPastAppointments.sql / patientUpcomingAppointments.sql). 

Issue: https://bahmni.atlassian.net/browse/AP-77

A MYSQL error was found when using openMRS 2.4.0.
The cause seems to be related with the functions inside the files:

patientPastAppointments.sql
patientPastAppointments_v2.sql
patientUpcomingAppointments.sql
patientUpcomingAppointments_v2.sql
After a closer look, root of the error seems to be the way some characters are escaped.

Solution:
The solution seems too be using different forms of "" and '' instead of relying on \ to do the character escaping