### PR TITLE
BAH-1209: Fetch appointments for non-voided patients only (Fix Regression)

### DIFF
--- a/api/src/main/java/org/openmrs/module/appointments/dao/impl/AppointmentDaoImpl.java
+++ b/api/src/main/java/org/openmrs/module/appointments/dao/impl/AppointmentDaoImpl.java
@@ -36,6 +36,7 @@ public class AppointmentDaoImpl implements AppointmentDao {
         criteria.add(Restrictions.eq("voided", false));
         criteria.createAlias("patient", "patient");
         criteria.add(Restrictions.eq("patient.voided", false));
+        criteria.add(Restrictions.eq("patient.personVoided", false));
         if (forDate != null) {
             Date maxDate = new Date(forDate.getTime() + TimeUnit.DAYS.toMillis(1));
             criteria.add(Restrictions.ge("startDateTime", forDate));
@@ -78,6 +79,7 @@ public class AppointmentDaoImpl implements AppointmentDao {
         criteria.add(Restrictions.eq("voided", false));
         criteria.createAlias("patient", "patient");
         criteria.add(Restrictions.eq("patient.voided", false));
+        criteria.add(Restrictions.eq("patient.personVoided", false));
         criteria.add(Restrictions.ne("status", AppointmentStatus.Cancelled));
         return criteria.list();
     }
@@ -90,6 +92,7 @@ public class AppointmentDaoImpl implements AppointmentDao {
         criteria.add(Restrictions.eq("voided", false));
         criteria.createAlias("patient", "patient");
         criteria.add(Restrictions.eq("patient.voided", false));
+        criteria.add(Restrictions.eq("patient.personVoided", false));
         criteria.add(Restrictions.ne("status", AppointmentStatus.Cancelled));
         return criteria.list();
     }
@@ -102,6 +105,7 @@ public class AppointmentDaoImpl implements AppointmentDao {
         criteria.add(Restrictions.eq("voided", false));
         criteria.createAlias("patient", "patient");
         criteria.add(Restrictions.eq("patient.voided", false));
+        criteria.add(Restrictions.eq("patient.personVoided", false));
         criteria.add(Restrictions.ge("startDateTime", startDate));
         criteria.add(Restrictions.le("startDateTime", endDate));
         criteria.createCriteria("service").add(Example.create(appointmentServiceDefinition));
@@ -125,6 +129,7 @@ public class AppointmentDaoImpl implements AppointmentDao {
         criteria.add(Restrictions.eq("voided", false));
         criteria.createAlias("patient", "patient");
         criteria.add(Restrictions.eq("patient.voided", false));
+        criteria.add(Restrictions.eq("patient.personVoided", false));
         if (startDate != null) {
             criteria.add(Restrictions.ge("startDateTime", startDate));
         }
@@ -159,6 +164,7 @@ public class AppointmentDaoImpl implements AppointmentDao {
     private void setPatientCriteria(AppointmentSearchRequest appointmentSearchRequest, Criteria criteria) {
         criteria.createAlias("patient", "patient");
         criteria.add(Restrictions.eq("patient.voided", false));
+        criteria.add(Restrictions.eq("patient.personVoided", false));
         if (StringUtils.isNotEmpty(appointmentSearchRequest.getPatientUuid())) {
             criteria.add(Restrictions.eq("patient.uuid", appointmentSearchRequest.getPatientUuid()));
         }
@@ -189,6 +195,7 @@ public class AppointmentDaoImpl implements AppointmentDao {
         criteria.add(Restrictions.eq("patient.patientId", patientId));
         criteria.add(Restrictions.eq("voided", false));
         criteria.add(Restrictions.eq("patient.voided", false));
+        criteria.add(Restrictions.eq("patient.personVoided", false));
         criteria.add(Restrictions.ge("startDateTime", DateUtil.getStartOfDay()));
 
         return criteria.list();


### PR DESCRIPTION
Issue: https://bahmni.atlassian.net/browse/AP-78

Appointments module seems not to be handling voided patients correctly. 

Regression: 
While in the past validation for Patient = Voided was enough 
Now, it seems that a Person can be voided while the Patient is still not voided. 
This causes an error.

Fix suggested:
Also validate for Person = voided