### PR TITLE
AP-82 - Timezone support for service definitions start and end times

### DIFF
--- a/omod/src/main/java/org/openmrs/module/appointments/web/mapper/AppointmentServiceMapper.java
+++ b/omod/src/main/java/org/openmrs/module/appointments/web/mapper/AppointmentServiceMapper.java
@@ -204,16 +204,19 @@ public class AppointmentServiceMapper {
     }
 
     private String convertTimeToString(Time time) {
+        if (time == null) {
+            return new String();
+        }
 
         Calendar timeCalendar = Calendar.getInstance();
         timeCalendar.setTime(time);
 
-        Calendar calendar = Calendar.getInstance();
+        Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
         calendar.set(Calendar.HOUR_OF_DAY, timeCalendar.get(Calendar.HOUR_OF_DAY));
         calendar.set(Calendar.MINUTE, timeCalendar.get(Calendar.MINUTE));
         calendar.set(Calendar.SECOND, 0);
         calendar.set(Calendar.MILLISECOND, 0);
 
-       return time != null ? calendar.toInstant().toString()  : new String();
+       return calendar.toInstant().toString();
     }
 }

--- a/omod/src/main/java/org/openmrs/module/appointments/web/mapper/AppointmentServiceMapper.java
+++ b/omod/src/main/java/org/openmrs/module/appointments/web/mapper/AppointmentServiceMapper.java
@@ -204,6 +204,16 @@ public class AppointmentServiceMapper {
     }
 
     private String convertTimeToString(Time time) {
-       return time != null ? time.toString() : new String();
+
+        Calendar timeCalendar = Calendar.getInstance();
+        timeCalendar.setTime(time);
+
+        Calendar calendar = Calendar.getInstance();
+        calendar.set(Calendar.HOUR_OF_DAY, timeCalendar.get(Calendar.HOUR_OF_DAY));
+        calendar.set(Calendar.MINUTE, timeCalendar.get(Calendar.MINUTE));
+        calendar.set(Calendar.SECOND, 0);
+        calendar.set(Calendar.MILLISECOND, 0);
+
+       return time != null ? calendar.toInstant().toString()  : new String();
     }
 }


### PR DESCRIPTION
**Ticket:** [AP-82](https://bahmni.atlassian.net/browse/AP-82)
**Description:** Reviewed services saving / loading to cope with timezones
- Include Date and timezone info when converting Time to String so that, when it's consumed, it can be properly converted to other timezones. We'll need to add current date to the time and not something like "January 01, 1970" to have the right hour whether we are on daylight saving time or not.