### PR TITLE
AP-84 - Add "age", "gender" and "patient identifiers" to Patient map

### DIFF
--- a/omod/src/main/java/org/openmrs/module/appointments/web/mapper/AppointmentMapper.java
+++ b/omod/src/main/java/org/openmrs/module/appointments/web/mapper/AppointmentMapper.java
@@ -277,6 +277,7 @@ public class AppointmentMapper {
         map.putAll(p.getActiveIdentifiers().stream()
                 .collect(Collectors.toMap(e -> e.getIdentifierType().toString().replaceAll("[- ]", ""),
                                             e -> e.getIdentifier())));
+
         return map;
     }
 

--- a/omod/src/main/java/org/openmrs/module/appointments/web/mapper/AppointmentMapper.java
+++ b/omod/src/main/java/org/openmrs/module/appointments/web/mapper/AppointmentMapper.java
@@ -277,7 +277,6 @@ public class AppointmentMapper {
         map.putAll(p.getActiveIdentifiers().stream()
                 .collect(Collectors.toMap(e -> e.getIdentifierType().toString().replaceAll("[- ]", ""),
                                             e -> e.getIdentifier())));
-
         return map;
     }
 

--- a/omod/src/main/java/org/openmrs/module/appointments/web/mapper/AppointmentMapper.java
+++ b/omod/src/main/java/org/openmrs/module/appointments/web/mapper/AppointmentMapper.java
@@ -34,6 +34,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @Component
 public class AppointmentMapper {
@@ -271,6 +272,11 @@ public class AppointmentMapper {
         map.put("name", p.getPersonName().getFullName());
         map.put("uuid", p.getUuid());
         map.put("identifier", p.getPatientIdentifier().getIdentifier());
+        map.put("age", p.getAge());
+        map.put("gender", p.getGender());
+        map.putAll(p.getActiveIdentifiers().stream()
+                .collect(Collectors.toMap(e -> e.getIdentifierType().toString().replaceAll("[- ]", ""),
+                                            e -> e.getIdentifier())));
         return map;
     }
 


### PR DESCRIPTION
Issue: https://bahmni.atlassian.net/browse/AP-84

The supported fields correspond to:
'APPOINTMENT_PATIENT_ID';  'APPOINTMENT_DATE'; 'APPOINTMENT_START_TIME_KEY'; 'APPOINTMENT_END_TIME_KEY'; 'APPOINTMENT_PROVIDER'; 'APPOINTMENT_SERVICE_SPECIALITY_KEY';
'APPOINTMENT_SERVICE'; 'APPOINTMENT_SERVICE_TYPE_FULL'; 'APPOINTMENT_STATUS'; 'APPOINTMENT_WALK_IN'; 'APPOINTMENT_SERVICE_LOCATION_KEY';
'APPOINTMENT_ADDITIONAL_INFO'; 'APPOINTMENT_CREATE_NOTES'

Our suggestion is to add 
Patient Age
Patient Gender
Patient Identifiers (other than patient identifier) 

To accomplish this, the map for Patient needs to have more information 
Because of that, we added patient age, gender, and list of identifiers