### PR TITLE
AP_85: Make table connection optional to fix 2.4 regression 

### DIFF
--- a/api/src/main/resources/Appointment.hbm.xml
+++ b/api/src/main/resources/Appointment.hbm.xml
@@ -56,7 +56,7 @@
             <one-to-many class="AppointmentAudit"/>
         </set>
 
-        <join table="patient_appointment_occurrence" inverse="true">
+        <join table="patient_appointment_occurrence" inverse="true" optional="true">
             <key column="patient_appointment_id"/>
             <many-to-one name="appointmentRecurringPattern" column="patient_appointment_timings_id"/>
         </join>


### PR DESCRIPTION
Issue: https://bahmni.atlassian.net/browse/AP-85

Saving an appointment without “Recurring Appointment” will make it return an exception.
This does not happen when saving a Recurring Appointment. 

Why is this a problem now:  
"2.4 upgrades from Hibernate 4.3 to Hibernate 5.4 and it looks like the way JOINs work was drastically re-written. I think the net result is that without that optional parameter, Hibernate now expects the JOIN to be an inner join" - @ibacher 

Solution: 
Making the connection table "patient_appointment_occurrence" optional