### PR TITLE
Bah 1649 - Upgrades openmrs atomfeed version to 2.6.2-SNAPSHOT

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -139,7 +139,7 @@
 		<dependency>
 			<groupId>com.sun.mail</groupId>
 			<artifactId>javax.mail</artifactId>
-			<version>1.6.2</version>
+			<version>${javaxMail.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<!-- End OpenMRS core -->

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,8 @@
 		<jacocoVersion>0.7.9</jacocoVersion>
 		<openmrsAtomfeedVersion>2.6.2-SNAPSHOT</openmrsAtomfeedVersion>
 		<atomfeed.version>1.10.1</atomfeed.version>
+		<javaxMail.version>1.6.2</javaxMail.version>
+		<webServices.version>2.29.0</webServices.version>
 	</properties>
 
 	<build>
@@ -175,13 +177,13 @@
 			<dependency>
 				<groupId>org.openmrs.module</groupId>
 				<artifactId>webservices.rest-omod</artifactId>
-				<version>2.29.0</version>
+				<version>${webServices.version}</version>
 				<scope>provided</scope>
 			</dependency>
 			<dependency>
 				<groupId>org.openmrs.module</groupId>
 				<artifactId>webservices.rest-omod-common</artifactId>
-				<version>2.29.0</version>
+				<version>${webServices.version}</version>
 				<scope>provided</scope>
 			</dependency>
 			<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
 		<mockitoVersion>3.5.11</mockitoVersion>
 		<argLine>-Xmx1024m</argLine>
 		<jacocoVersion>0.7.9</jacocoVersion>
-		<openmrsAtomfeedVersion>2.6.1</openmrsAtomfeedVersion>
+		<openmrsAtomfeedVersion>2.6.2-SNAPSHOT</openmrsAtomfeedVersion>
 		<atomfeed.version>1.10.1</atomfeed.version>
 	</properties>
 


### PR DESCRIPTION
This PR is about:
- Using versions in properties instead of hardcoded versions
- Upgrades openmrs atomfeed version to 2.6.2-SNAPSHOT