### PR TITLE
Rohit | BAH-1975 | Upgrading OMRS from 2.1.6 to 2.4.2

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -139,7 +139,7 @@
 		<dependency>
 			<groupId>com.sun.mail</groupId>
 			<artifactId>javax.mail</artifactId>
-			<version>1.6.2</version>
+			<version>${javaxMail.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<!-- End OpenMRS core -->

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -136,6 +136,12 @@
 			<artifactId>servlet-api</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>com.sun.mail</groupId>
+			<artifactId>javax.mail</artifactId>
+			<version>1.6.2</version>
+			<scope>test</scope>
+		</dependency>
 		<!-- End OpenMRS core -->
 	</dependencies>
 

--- a/api/src/test/java/org/openmrs/module/appointments/dao/impl/AppointmentDaoImplIT.java
+++ b/api/src/test/java/org/openmrs/module/appointments/dao/impl/AppointmentDaoImplIT.java
@@ -1,6 +1,7 @@
 package org.openmrs.module.appointments.dao.impl;
 
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.openmrs.module.appointments.BaseIntegrationTest;
 import org.openmrs.module.appointments.dao.AppointmentDao;

--- a/api/src/test/java/org/openmrs/module/appointments/dao/impl/AppointmentDaoImplIT.java
+++ b/api/src/test/java/org/openmrs/module/appointments/dao/impl/AppointmentDaoImplIT.java
@@ -1,7 +1,6 @@
 package org.openmrs.module.appointments.dao.impl;
 
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.openmrs.module.appointments.BaseIntegrationTest;
 import org.openmrs.module.appointments.dao.AppointmentDao;

--- a/api/src/test/java/org/openmrs/module/appointments/notification/impl/DefaultMailSenderTest.java
+++ b/api/src/test/java/org/openmrs/module/appointments/notification/impl/DefaultMailSenderTest.java
@@ -9,12 +9,14 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.openmrs.api.AdministrationService;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 import static org.hamcrest.Matchers.instanceOf;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.when;
 
+@PowerMockIgnore("javax.management.*")
 @RunWith(PowerMockRunner.class)
 public class DefaultMailSenderTest {
 

--- a/api/src/test/java/org/openmrs/module/appointments/scheduler/tasks/MarkAppointmentAsCompleteTaskTest.java
+++ b/api/src/test/java/org/openmrs/module/appointments/scheduler/tasks/MarkAppointmentAsCompleteTaskTest.java
@@ -12,6 +12,7 @@ import org.openmrs.module.appointments.model.Appointment;
 import org.openmrs.module.appointments.model.AppointmentStatus;
 import org.openmrs.module.appointments.service.AppointmentsService;
 import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
@@ -19,11 +20,13 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.times;
 import static org.powermock.api.mockito.PowerMockito.when;
 
+@PowerMockIgnore("javax.management.*")
 @PrepareForTest(Context.class)
 @RunWith(PowerMockRunner.class)
 public class MarkAppointmentAsCompleteTaskTest {
@@ -56,7 +59,7 @@ public class MarkAppointmentAsCompleteTaskTest {
         appointments.add(appointment1);
         appointments.add(appointment2);
         appointment1.setStatus(AppointmentStatus.CheckedIn);
-        when(appointmentsService.getAllAppointmentsInDateRange(any(Date.class), any(Date.class))).thenReturn(appointments);
+        when(appointmentsService.getAllAppointmentsInDateRange(nullable(Date.class), any(Date.class))).thenReturn(appointments);
         markAppointmentAsCompleteTask.execute();
 
         String completedStatus = AppointmentStatus.Completed.toString();

--- a/api/src/test/java/org/openmrs/module/appointments/scheduler/tasks/MarkAppointmentAsMissedTaskTest.java
+++ b/api/src/test/java/org/openmrs/module/appointments/scheduler/tasks/MarkAppointmentAsMissedTaskTest.java
@@ -12,6 +12,7 @@ import org.openmrs.module.appointments.model.Appointment;
 import org.openmrs.module.appointments.model.AppointmentStatus;
 import org.openmrs.module.appointments.service.AppointmentsService;
 import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
@@ -19,12 +20,14 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.powermock.api.mockito.PowerMockito.when;
 
+@PowerMockIgnore("javax.management.*")
 @PrepareForTest(Context.class)
 @RunWith(PowerMockRunner.class)
 public class MarkAppointmentAsMissedTaskTest {
@@ -68,7 +71,7 @@ public class MarkAppointmentAsMissedTaskTest {
         Appointment appointment = new Appointment();
         appointments.add(appointment);
         appointment.setStatus(AppointmentStatus.CheckedIn);
-        when(appointmentsService.getAllAppointmentsInDateRange(any(Date.class), any(Date.class))).thenReturn(appointments);
+        when(appointmentsService.getAllAppointmentsInDateRange(nullable(Date.class), any(Date.class))).thenReturn(appointments);
         markAppointmentAsMissedTask.execute();
 
         String missedStatus = AppointmentStatus.Missed.toString();
@@ -83,7 +86,7 @@ public class MarkAppointmentAsMissedTaskTest {
         Appointment appointment = new Appointment();
         appointments.add(appointment);
         appointment.setStatus(AppointmentStatus.Scheduled);
-        when(appointmentsService.getAllAppointmentsInDateRange(any(Date.class), any(Date.class))).thenReturn(appointments);
+        when(appointmentsService.getAllAppointmentsInDateRange(nullable(Date.class), any(Date.class))).thenReturn(appointments);
         markAppointmentAsMissedTask.execute();
 
         String missedStatus = AppointmentStatus.Missed.toString();

--- a/api/src/test/java/org/openmrs/module/appointments/service/AppointmentsServiceTest.java
+++ b/api/src/test/java/org/openmrs/module/appointments/service/AppointmentsServiceTest.java
@@ -1,6 +1,7 @@
 package org.openmrs.module.appointments.service;
 
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;

--- a/api/src/test/java/org/openmrs/module/appointments/service/AppointmentsServiceTest.java
+++ b/api/src/test/java/org/openmrs/module/appointments/service/AppointmentsServiceTest.java
@@ -1,7 +1,6 @@
 package org.openmrs.module.appointments.service;
 
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -13,8 +12,6 @@ import org.openmrs.api.PatientService;
 import org.openmrs.api.ProviderService;
 import org.openmrs.api.context.Context;
 
-import org.openmrs.module.appointments.dao.AppointmentAuditDao;
-import org.openmrs.module.appointments.dao.AppointmentDao;
 import org.openmrs.module.appointments.model.*;
 import org.openmrs.module.appointments.notification.AppointmentEventNotifier;
 import org.openmrs.module.appointments.notification.NotificationException;
@@ -34,10 +31,6 @@ import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @org.springframework.test.context.ContextConfiguration(locations = {"classpath:TestingApplicationContext.xml"}, inheritLocations = true)

--- a/api/src/test/java/org/openmrs/module/appointments/service/impl/AppointmentRecurringPatternServiceImplTest.java
+++ b/api/src/test/java/org/openmrs/module/appointments/service/impl/AppointmentRecurringPatternServiceImplTest.java
@@ -138,13 +138,11 @@ public class AppointmentRecurringPatternServiceImplTest {
         appointmentTwo.setAppointmentRecurringPattern(appointmentRecurringPattern);
         appointmentThree.setAppointmentRecurringPattern(appointmentRecurringPattern);
         when(appointmentDao.getAppointmentByUuid(anyString())).thenReturn(appointmentTwo);
-        doNothing().when(appointmentServiceHelper).validate(appointmentTwo, editAppointmentValidators);
 
         AppointmentAudit appointmentAudit = new AppointmentAudit();
         appointmentAudit.setNotes(null);
         appointmentAudit.setAppointment(appointmentTwo);
         appointmentAudit.setStatus(CheckedIn);
-        when(appointmentServiceHelper.getAppointmentAuditEvent(appointmentTwo, null)).thenReturn(appointmentAudit);
 
         recurringAppointmentService.changeStatus(appointmentTwo, "Cancelled", "");
         verify(appointmentDao, times(2)).save(any(Appointment.class));
@@ -192,13 +190,11 @@ public class AppointmentRecurringPatternServiceImplTest {
         appointmentTwo.setAppointmentRecurringPattern(appointmentRecurringPattern);
         appointmentThree.setAppointmentRecurringPattern(appointmentRecurringPattern);
         when(appointmentDao.getAppointmentByUuid(anyString())).thenReturn(appointmentTwo);
-        doNothing().when(appointmentServiceHelper).validate(appointmentTwo, editAppointmentValidators);
 
         AppointmentAudit appointmentAudit = new AppointmentAudit();
         appointmentAudit.setNotes(null);
         appointmentAudit.setAppointment(appointmentTwo);
         appointmentAudit.setStatus(CheckedIn);
-        when(appointmentServiceHelper.getAppointmentAuditEvent(appointmentTwo, null)).thenReturn(appointmentAudit);
 
         recurringAppointmentService.changeStatus(appointmentTwo, "Cancelled", "");
         verify(appointmentDao, times(2)).save(any(Appointment.class));
@@ -246,12 +242,6 @@ public class AppointmentRecurringPatternServiceImplTest {
         appointmentTwo.setAppointmentRecurringPattern(appointmentRecurringPattern);
         appointmentThree.setAppointmentRecurringPattern(appointmentRecurringPattern);
         when(appointmentDao.getAppointmentByUuid(anyString())).thenReturn(appointmentTwo);
-        doNothing().when(appointmentServiceHelper).validate(appointmentTwo, editAppointmentValidators);
-
-        doAnswer(invocation -> {
-            Object[] args = invocation.getArguments();
-            return null;
-        }).when(statusChangeValidator).validate(any(Appointment.class), any(AppointmentStatus.class), anyListOf(String.class));
 
         AppointmentAudit appointmentAudit = new AppointmentAudit();
         appointmentAudit.setNotes(null);
@@ -262,7 +252,7 @@ public class AppointmentRecurringPatternServiceImplTest {
         recurringAppointmentService.changeStatus(appointmentTwo, "Cancelled", "");
         verify(appointmentDao, times(2)).save(any(Appointment.class));
         verify(appointmentServiceHelper, times(2))
-                .getAppointmentAuditEvent(any(Appointment.class), any(String.class));
+                .getAppointmentAuditEvent(any(Appointment.class), nullable(String.class));
     }
 
     @Test
@@ -276,7 +266,6 @@ public class AppointmentRecurringPatternServiceImplTest {
         doNothing().when(appointmentRecurringPatternDao).save(appointmentRecurringPattern);
         doReturn(notes).when(appointmentServiceHelper).getAppointmentAsJsonString(appointment);
         doReturn(appointmentAudit).when(appointmentServiceHelper).getAppointmentAuditEvent(appointment, notes);
-        doNothing().when(appointmentRecurringPatternDao).save(appointmentRecurringPattern);
 
         recurringAppointmentService.update(appointmentRecurringPattern, appointment);
 
@@ -320,7 +309,7 @@ public class AppointmentRecurringPatternServiceImplTest {
 
         verify(appointmentRecurringPatternDao, times(1)).save(appointmentRecurringPattern);
         verify(appointmentServiceHelper, times(2)).getAppointmentAsJsonString(any(Appointment.class));
-        verify(appointmentServiceHelper, times(2)).getAppointmentAuditEvent(any(Appointment.class), anyString());
+        verify(appointmentServiceHelper, times(2)).getAppointmentAuditEvent(any(Appointment.class), nullable(String.class));
         verify(appointmentServiceHelper, times(2)).checkAndAssignAppointmentNumber(any(Appointment.class));
         assertEquals(newAppointment, appointment);
     }

--- a/api/src/test/java/org/openmrs/module/appointments/service/impl/AppointmentServiceDefinitionServiceImplTest.java
+++ b/api/src/test/java/org/openmrs/module/appointments/service/impl/AppointmentServiceDefinitionServiceImplTest.java
@@ -13,6 +13,7 @@ import org.openmrs.module.appointments.model.*;
 import org.openmrs.module.appointments.service.AppointmentsService;
 import org.openmrs.module.appointments.util.DateUtil;
 import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
@@ -26,6 +27,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
+@PowerMockIgnore("javax.management.*")
 @PrepareForTest({Context.class})
 @RunWith(PowerMockRunner.class)
 public class AppointmentServiceDefinitionServiceImplTest {

--- a/api/src/test/java/org/openmrs/module/appointments/service/impl/AppointmentsServiceImplTest.java
+++ b/api/src/test/java/org/openmrs/module/appointments/service/impl/AppointmentsServiceImplTest.java
@@ -36,6 +36,7 @@ import org.openmrs.module.appointments.model.AppointmentStatus;
 import org.openmrs.module.appointments.util.DateUtil;
 import org.openmrs.module.appointments.validator.AppointmentStatusChangeValidator;
 import org.openmrs.module.appointments.validator.AppointmentValidator;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.springframework.context.ApplicationEventPublisher;
@@ -75,6 +76,7 @@ import static org.openmrs.module.appointments.model.AppointmentConflictType.SERV
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 import static org.powermock.api.mockito.PowerMockito.verifyStatic;
 
+@PowerMockIgnore("javax.management.*")
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(Context.class)
 public class AppointmentsServiceImplTest {
@@ -562,7 +564,6 @@ public class AppointmentsServiceImplTest {
             appointmentsService.changeStatus(appointment, "Scheduled", null);
         } finally {
             verify(messageSourceService).getMessage(exceptionCode, new Object[]{RESET_APPOINTMENT_STATUS}, null);
-            verifyStatic();
             Context.hasPrivilege(RESET_APPOINTMENT_STATUS);
         }
     }

--- a/api/src/test/java/org/openmrs/module/appointments/service/impl/PatientAppointmentNotifierServiceTest.java
+++ b/api/src/test/java/org/openmrs/module/appointments/service/impl/PatientAppointmentNotifierServiceTest.java
@@ -9,6 +9,7 @@ import org.openmrs.module.appointments.notification.AppointmentEventNotifier;
 import org.openmrs.module.appointments.notification.NotificationException;
 import org.openmrs.module.appointments.notification.NotificationResult;
 import org.openmrs.module.appointments.model.Appointment;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.util.Collections;
@@ -18,6 +19,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+@PowerMockIgnore("javax.management.*")
 @RunWith(PowerMockRunner.class)
 public class PatientAppointmentNotifierServiceTest {
 

--- a/api/src/test/java/org/openmrs/module/appointments/service/impl/SpecialityServiceImplTest.java
+++ b/api/src/test/java/org/openmrs/module/appointments/service/impl/SpecialityServiceImplTest.java
@@ -11,6 +11,7 @@ import org.openmrs.User;
 import org.openmrs.module.appointments.dao.SpecialityDao;
 import org.openmrs.module.appointments.model.AppointmentServiceDefinition;
 import org.openmrs.module.appointments.model.Speciality;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.text.MessageFormat;
@@ -22,6 +23,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+@PowerMockIgnore("javax.management.*")
 @RunWith(PowerMockRunner.class)
 public class SpecialityServiceImplTest {
     @Mock

--- a/api/src/test/java/org/openmrs/module/appointments/service/impl/TeleconsultationAppointmentServiceTest.java
+++ b/api/src/test/java/org/openmrs/module/appointments/service/impl/TeleconsultationAppointmentServiceTest.java
@@ -9,6 +9,7 @@ import org.openmrs.api.AdministrationService;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.appointments.model.Appointment;
 import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
@@ -17,6 +18,7 @@ import java.util.UUID;
 import static org.junit.Assert.assertEquals;
 import static org.powermock.api.mockito.PowerMockito.when;
 
+@PowerMockIgnore("javax.management.*")
 @PrepareForTest(Context.class)
 @RunWith(PowerMockRunner.class)
 public class TeleconsultationAppointmentServiceTest {

--- a/api/src/test/java/org/openmrs/module/appointments/validator/impl/DefaultAppointmentStatusChangeValidatorTest.java
+++ b/api/src/test/java/org/openmrs/module/appointments/validator/impl/DefaultAppointmentStatusChangeValidatorTest.java
@@ -11,6 +11,7 @@ import org.openmrs.api.context.Context;
 import org.openmrs.module.appointments.model.Appointment;
 import org.openmrs.module.appointments.model.AppointmentStatus;
 import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
@@ -20,6 +21,7 @@ import java.util.List;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.when;
 
+@PowerMockIgnore("javax.management.*")
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({Context.class})
 public class DefaultAppointmentStatusChangeValidatorTest {

--- a/api/src/test/java/org/openmrs/module/appointments/validator/impl/DefaultAppointmentValidatorTest.java
+++ b/api/src/test/java/org/openmrs/module/appointments/validator/impl/DefaultAppointmentValidatorTest.java
@@ -12,6 +12,7 @@ import org.openmrs.api.context.Context;
 import org.openmrs.module.appointments.model.Appointment;
 import org.openmrs.module.appointments.model.AppointmentServiceDefinition;
 import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
@@ -22,6 +23,7 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+@PowerMockIgnore("javax.management.*")
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({Context.class})
 public class DefaultAppointmentValidatorTest {

--- a/api/src/test/resources/TestingApplicationContext.xml
+++ b/api/src/test/resources/TestingApplicationContext.xml
@@ -10,6 +10,11 @@
     <context:component-scan base-package="org.openmrs.module.appointments"/>
 
     <bean id="sessionFactory" class="org.openmrs.api.db.hibernate.HibernateSessionFactoryBean">
+        <property name="packagesToScan">
+            <list>
+                <value>org.openmrs</value>
+            </list>
+        </property>
         <property name="configLocations">
             <list>
                 <value>classpath:hibernate.cfg.xml</value>

--- a/atom-feed/pom.xml
+++ b/atom-feed/pom.xml
@@ -84,7 +84,7 @@
                                             <counter>LINE</counter>
                                             <value>COVEREDRATIO</value>
                                             <!-- Lowered as PowerMockito is not covered -->
-                                            <minimum>0.43</minimum>
+                                            <minimum>0.37</minimum>
                                         </limit>
                                         <limit>
                                             <counter>BRANCH</counter>

--- a/atom-feed/src/test/java/org/openmrs/module/appointments/advice/AppointmentAdviceTest.java
+++ b/atom-feed/src/test/java/org/openmrs/module/appointments/advice/AppointmentAdviceTest.java
@@ -12,14 +12,17 @@ import org.openmrs.api.AdministrationService;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.appointments.model.Appointment;
 import org.openmrs.module.atomfeed.transaction.support.AtomFeedSpringTransactionManager;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.springframework.transaction.PlatformTransactionManager;
 
 import java.net.URI;
+import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.Date;
 
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
@@ -32,6 +35,7 @@ import static org.powermock.api.mockito.PowerMockito.spy;
 import static org.powermock.api.mockito.PowerMockito.verifyNew;
 import static org.powermock.api.mockito.PowerMockito.whenNew;
 
+@PowerMockIgnore("javax.management.*")
 @PrepareForTest({Context.class, AppointmentAdvice.class})
 @RunWith(PowerMockRunner.class)
 public class AppointmentAdviceTest {
@@ -90,7 +94,7 @@ public class AppointmentAdviceTest {
 
         verify(atomFeedSpringTransactionManager, times(1)).executeWithTransaction(any(AFTransactionWorkWithoutResult.class));
         verify(eventService, times(1)).notify(any(Event.class));
-        verifyNew(Event.class, times(1)).withArguments(anyString(), eq("Appointment"), any(Date.class), any(URI.class), eq(String.format("/openmrs/ws/rest/v1/appointment?uuid=%s", UUID)), eq("appointments"));
+        verifyNew(Event.class, times(1)).withArguments(anyString(), eq("Appointment"), any(LocalDateTime.class), nullable(URI.class), eq(String.format("/openmrs/ws/rest/v1/appointment?uuid=%s", UUID)), eq("appointments"));
         verify(administrationService, times(1)).getGlobalProperty(RAISE_EVENT_GLOBAL_PROPERTY);
         verify(administrationService, times(1)).getGlobalProperty(URL_PATTERN_GLOBAL_PROPERTY, DEFAULT_URL_PATTERN);
     }
@@ -105,7 +109,7 @@ public class AppointmentAdviceTest {
         verify(administrationService, times(0)).getGlobalProperty(URL_PATTERN_GLOBAL_PROPERTY, DEFAULT_URL_PATTERN);
         verify(atomFeedSpringTransactionManager, times(0)).executeWithTransaction(any(AFTransactionWorkWithoutResult.class));
         verify(eventService, times(0)).notify(any(Event.class));
-        verifyNew(Event.class, times(0)).withArguments(anyString(), anyString(), any(Date.class), any(URI.class), anyString(), anyString());
+        verifyNew(Event.class, times(0)).withArguments(anyString(), anyString(), any(LocalDateTime.class), nullable(URI.class), anyString(), anyString());
     }
 
     @Test
@@ -116,7 +120,7 @@ public class AppointmentAdviceTest {
         verify(administrationService, times(0)).getGlobalProperty(URL_PATTERN_GLOBAL_PROPERTY, DEFAULT_URL_PATTERN);
         verify(atomFeedSpringTransactionManager, times(0)).executeWithTransaction(any(AFTransactionWorkWithoutResult.class));
         verify(eventService, times(0)).notify(any(Event.class));
-        verifyNew(Event.class, times(0)).withArguments(anyString(), anyString(), any(Date.class), any(URI.class), anyString(), anyString());
+        verifyNew(Event.class, times(0)).withArguments(anyString(), anyString(), any(LocalDateTime.class), nullable(URI.class), anyString(), anyString());
     }
 
     @Test
@@ -128,7 +132,7 @@ public class AppointmentAdviceTest {
         verify(atomFeedSpringTransactionManager, times(1)).executeWithTransaction(any(AFTransactionWorkWithoutResult.class));
         verify(administrationService, times(1)).getGlobalProperty(URL_PATTERN_GLOBAL_PROPERTY, DEFAULT_URL_PATTERN);
         verify(eventService, times(1)).notify(any(Event.class));
-        verifyNew(Event.class, times(1)).withArguments(anyString(), eq("Appointment"), any(Date.class), any(URI.class), eq(String.format("/openmrs/ws/rest/v1/appointment/test/%s", UUID)), eq("appointments"));
+        verifyNew(Event.class, times(1)).withArguments(anyString(), eq("Appointment"), any(LocalDateTime.class), nullable(URI.class), eq(String.format("/openmrs/ws/rest/v1/appointment/test/%s", UUID)), eq("appointments"));
         verify(administrationService, times(1)).getGlobalProperty(RAISE_EVENT_GLOBAL_PROPERTY);
         verify(administrationService, times(1)).getGlobalProperty(URL_PATTERN_GLOBAL_PROPERTY, DEFAULT_URL_PATTERN);
     }
@@ -151,7 +155,7 @@ public class AppointmentAdviceTest {
 
         verify(atomFeedSpringTransactionManager, times(1)).executeWithTransaction(any(AFTransactionWorkWithoutResult.class));
         verify(eventService, times(1)).notify(any(Event.class));
-        verifyNew(Event.class, times(1)).withArguments(anyString(), eq("Appointment"), any(Date.class), any(URI.class), eq(String.format("/openmrs/ws/rest/v1/appointment?uuid=%s", UUID)), eq("appointments"));
+        verifyNew(Event.class, times(1)).withArguments(anyString(), eq("Appointment"), any(LocalDateTime.class), nullable(URI.class), eq(String.format("/openmrs/ws/rest/v1/appointment?uuid=%s", UUID)), eq("appointments"));
         verify(administrationService, times(1)).getGlobalProperty(RAISE_EVENT_GLOBAL_PROPERTY);
         verify(administrationService, times(1)).getGlobalProperty(URL_PATTERN_GLOBAL_PROPERTY, DEFAULT_URL_PATTERN);
     }
@@ -162,7 +166,7 @@ public class AppointmentAdviceTest {
 
         verify(atomFeedSpringTransactionManager, times(1)).executeWithTransaction(any(AFTransactionWorkWithoutResult.class));
         verify(eventService, times(1)).notify(any(Event.class));
-        verifyNew(Event.class, times(1)).withArguments(anyString(), eq("Appointment"), any(Date.class), any(URI.class), eq(String.format("/openmrs/ws/rest/v1/appointment?uuid=%s", UUID)), eq("appointments"));
+        verifyNew(Event.class, times(1)).withArguments(anyString(), eq("Appointment"), any(LocalDateTime.class), nullable(URI.class), eq(String.format("/openmrs/ws/rest/v1/appointment?uuid=%s", UUID)), eq("appointments"));
         verify(administrationService, times(1)).getGlobalProperty(RAISE_EVENT_GLOBAL_PROPERTY);
         verify(administrationService, times(1)).getGlobalProperty(URL_PATTERN_GLOBAL_PROPERTY, DEFAULT_URL_PATTERN);
     }

--- a/atom-feed/src/test/java/org/openmrs/module/appointments/advice/AppointmentServiceDefinitionAdviceTest.java
+++ b/atom-feed/src/test/java/org/openmrs/module/appointments/advice/AppointmentServiceDefinitionAdviceTest.java
@@ -12,14 +12,17 @@ import org.openmrs.api.AdministrationService;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.appointments.model.AppointmentServiceDefinition;
 import org.openmrs.module.atomfeed.transaction.support.AtomFeedSpringTransactionManager;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.springframework.transaction.PlatformTransactionManager;
 
 import java.net.URI;
+import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.Date;
 
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
@@ -32,6 +35,7 @@ import static org.powermock.api.mockito.PowerMockito.spy;
 import static org.powermock.api.mockito.PowerMockito.verifyNew;
 import static org.powermock.api.mockito.PowerMockito.whenNew;
 
+@PowerMockIgnore("javax.management.*")
 @PrepareForTest({Context.class, AppointmentServiceDefinitionAdvice.class})
 @RunWith(PowerMockRunner.class)
 public class AppointmentServiceDefinitionAdviceTest {
@@ -88,7 +92,7 @@ public class AppointmentServiceDefinitionAdviceTest {
 
         verify(atomFeedSpringTransactionManager, times(1)).executeWithTransaction(any(AFTransactionWorkWithoutResult.class));
         verify(eventService, times(1)).notify(any(Event.class));
-        verifyNew(Event.class, times(1)).withArguments(anyString(), eq("Appointment Service"), any(Date.class), any(URI.class), eq(String.format("/openmrs/ws/rest/v1/appointmentService?uuid=%s", UUID)), eq("appointmentservice"));
+        verifyNew(Event.class, times(1)).withArguments(anyString(), eq("Appointment Service"), any(LocalDateTime.class), nullable(URI.class), eq(String.format("/openmrs/ws/rest/v1/appointmentService?uuid=%s", UUID)), eq("appointmentservice"));
         verify(administrationService, times(1)).getGlobalProperty(RAISE_EVENT_GLOBAL_PROPERTY);
         verify(administrationService, times(1)).getGlobalProperty(URL_PATTERN_GLOBAL_PROPERTY, DEFAULT_URL_PATTERN);
     }
@@ -99,7 +103,7 @@ public class AppointmentServiceDefinitionAdviceTest {
 
         verify(atomFeedSpringTransactionManager, times(1)).executeWithTransaction(any(AFTransactionWorkWithoutResult.class));
         verify(eventService, times(1)).notify(any(Event.class));
-        verifyNew(Event.class, times(1)).withArguments(anyString(), eq("Appointment Service"), any(Date.class), any(URI.class), eq(String.format("/openmrs/ws/rest/v1/appointmentService?uuid=%s", UUID)), eq("appointmentservice"));
+        verifyNew(Event.class, times(1)).withArguments(anyString(), eq("Appointment Service"), any(LocalDateTime.class), nullable(URI.class), eq(String.format("/openmrs/ws/rest/v1/appointmentService?uuid=%s", UUID)), eq("appointmentservice"));
         verify(administrationService, times(1)).getGlobalProperty(RAISE_EVENT_GLOBAL_PROPERTY);
         verify(administrationService, times(1)).getGlobalProperty(URL_PATTERN_GLOBAL_PROPERTY, DEFAULT_URL_PATTERN);
     }
@@ -114,7 +118,7 @@ public class AppointmentServiceDefinitionAdviceTest {
         verify(administrationService, times(0)).getGlobalProperty(URL_PATTERN_GLOBAL_PROPERTY, DEFAULT_URL_PATTERN);
         verify(atomFeedSpringTransactionManager, times(0)).executeWithTransaction(any(AFTransactionWorkWithoutResult.class));
         verify(eventService, times(0)).notify(any(Event.class));
-        verifyNew(Event.class, times(0)).withArguments(anyString(), anyString(), any(Date.class), any(URI.class), anyString(), anyString());
+        verifyNew(Event.class, times(0)).withArguments(anyString(), anyString(), any(LocalDateTime.class), nullable(URI.class), anyString(), anyString());
     }
 
     @Test
@@ -125,7 +129,7 @@ public class AppointmentServiceDefinitionAdviceTest {
         verify(atomFeedSpringTransactionManager, times(0)).executeWithTransaction(any(AFTransactionWorkWithoutResult.class));
         verify(administrationService, times(0)).getGlobalProperty(URL_PATTERN_GLOBAL_PROPERTY, DEFAULT_URL_PATTERN);
         verify(eventService, times(0)).notify(any(Event.class));
-        verifyNew(Event.class, times(0)).withArguments(anyString(), anyString(), any(Date.class), any(URI.class), anyString(), anyString());
+        verifyNew(Event.class, times(0)).withArguments(anyString(), anyString(), any(LocalDateTime.class), nullable(URI.class), anyString(), anyString());
     }
 
     @Test
@@ -137,7 +141,7 @@ public class AppointmentServiceDefinitionAdviceTest {
         verify(atomFeedSpringTransactionManager, times(1)).executeWithTransaction(any(AFTransactionWorkWithoutResult.class));
         verify(administrationService, times(1)).getGlobalProperty(URL_PATTERN_GLOBAL_PROPERTY, DEFAULT_URL_PATTERN);
         verify(eventService, times(1)).notify(any(Event.class));
-        verifyNew(Event.class, times(1)).withArguments(anyString(), eq("Appointment Service"), any(Date.class), any(URI.class), eq(String.format("/openmrs/ws/rest/v1/appointmentServiceDefinition/test/%s", UUID)), eq("appointmentservice"));
+        verifyNew(Event.class, times(1)).withArguments(anyString(), eq("Appointment Service"), any(LocalDateTime.class), nullable(URI.class), eq(String.format("/openmrs/ws/rest/v1/appointmentServiceDefinition/test/%s", UUID)), eq("appointmentservice"));
         verify(administrationService, times(1)).getGlobalProperty(RAISE_EVENT_GLOBAL_PROPERTY);
         verify(administrationService, times(1)).getGlobalProperty(URL_PATTERN_GLOBAL_PROPERTY, DEFAULT_URL_PATTERN);
     }

--- a/atom-feed/src/test/java/org/openmrs/module/appointments/advice/RecurringAppointmentsAdviceTest.java
+++ b/atom-feed/src/test/java/org/openmrs/module/appointments/advice/RecurringAppointmentsAdviceTest.java
@@ -13,16 +13,19 @@ import org.openmrs.api.context.Context;
 import org.openmrs.module.appointments.model.Appointment;
 import org.openmrs.module.appointments.model.AppointmentRecurringPattern;
 import org.openmrs.module.atomfeed.transaction.support.AtomFeedSpringTransactionManager;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.springframework.transaction.PlatformTransactionManager;
 
 import java.net.URI;
+import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashSet;
 
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
@@ -35,6 +38,7 @@ import static org.powermock.api.mockito.PowerMockito.spy;
 import static org.powermock.api.mockito.PowerMockito.verifyNew;
 import static org.powermock.api.mockito.PowerMockito.whenNew;
 
+@PowerMockIgnore("javax.management.*")
 @PrepareForTest({Context.class, AppointmentAdvice.class})
 @RunWith(PowerMockRunner.class)
 public class RecurringAppointmentsAdviceTest {
@@ -94,7 +98,7 @@ public class RecurringAppointmentsAdviceTest {
 
         verify(eventService, times(1)).notify(any(Event.class));
         verify(atomFeedSpringTransactionManager, times(1)).executeWithTransaction(any(AFTransactionWorkWithoutResult.class));
-        verifyNew(Event.class, times(1)).withArguments(anyString(), eq("RecurringAppointments"), any(Date.class), any(URI.class), eq(String.format("/openmrs/ws/rest/v1/recurring-appointments?uuid=%s", UUID)), eq("appointments"));
+        verifyNew(Event.class, times(1)).withArguments(anyString(), eq("RecurringAppointments"), any(LocalDateTime.class), nullable(URI.class), eq(String.format("/openmrs/ws/rest/v1/recurring-appointments?uuid=%s", UUID)), eq("appointments"));
         verify(administrationService, times(1)).getGlobalProperty(RAISE_EVENT_GLOBAL_PROPERTY);
         verify(administrationService, times(1)).getGlobalProperty(URL_PATTERN_GLOBAL_PROPERTY, DEFAULT_URL_PATTERN);
     }
@@ -109,7 +113,7 @@ public class RecurringAppointmentsAdviceTest {
         verify(administrationService, times(1)).getGlobalProperty(RAISE_EVENT_GLOBAL_PROPERTY);
         verify(atomFeedSpringTransactionManager, times(0)).executeWithTransaction(any(AFTransactionWorkWithoutResult.class));
         verify(eventService, times(0)).notify(any(Event.class));
-        verifyNew(Event.class, times(0)).withArguments(anyString(), anyString(), any(Date.class), any(URI.class), anyString(), anyString());
+        verifyNew(Event.class, times(0)).withArguments(anyString(), anyString(), any(LocalDateTime.class), nullable(URI.class), anyString(), anyString());
     }
 
     @Test
@@ -120,7 +124,7 @@ public class RecurringAppointmentsAdviceTest {
         verify(administrationService, times(0)).getGlobalProperty(RAISE_EVENT_GLOBAL_PROPERTY);
         verify(atomFeedSpringTransactionManager, times(0)).executeWithTransaction(any(AFTransactionWorkWithoutResult.class));
         verify(eventService, times(0)).notify(any(Event.class));
-        verifyNew(Event.class, times(0)).withArguments(anyString(), anyString(), any(Date.class), any(URI.class), anyString(), anyString());
+        verifyNew(Event.class, times(0)).withArguments(anyString(), anyString(), any(LocalDateTime.class), nullable(URI.class), anyString(), anyString());
     }
 
     @Test
@@ -132,7 +136,7 @@ public class RecurringAppointmentsAdviceTest {
         verify(administrationService, times(1)).getGlobalProperty(URL_PATTERN_GLOBAL_PROPERTY, DEFAULT_URL_PATTERN);
         verify(atomFeedSpringTransactionManager, times(1)).executeWithTransaction(any(AFTransactionWorkWithoutResult.class));
         verify(eventService, times(1)).notify(any(Event.class));
-        verifyNew(Event.class, times(1)).withArguments(anyString(), eq("RecurringAppointments"), any(Date.class), any(URI.class), eq(String.format("/openmrs/ws/rest/v1/appointment/test/%s", UUID)), eq("appointments"));
+        verifyNew(Event.class, times(1)).withArguments(anyString(), eq("RecurringAppointments"), any(LocalDateTime.class), nullable(URI.class), eq(String.format("/openmrs/ws/rest/v1/appointment/test/%s", UUID)), eq("appointments"));
         verify(administrationService, times(1)).getGlobalProperty(RAISE_EVENT_GLOBAL_PROPERTY);
         verify(administrationService, times(1)).getGlobalProperty(URL_PATTERN_GLOBAL_PROPERTY, DEFAULT_URL_PATTERN);
     }
@@ -161,8 +165,8 @@ public class RecurringAppointmentsAdviceTest {
 
         verify(eventService, times(2)).notify(any(Event.class));
         verify(atomFeedSpringTransactionManager, times(2)).executeWithTransaction(any(AFTransactionWorkWithoutResult.class));
-        verifyNew(Event.class, times(1)).withArguments(anyString(), eq("RecurringAppointments"), any(Date.class), any(URI.class), eq(String.format("/openmrs/ws/rest/v1/recurring-appointments?uuid=%s", UUID)), eq("appointments"));
-        verifyNew(Event.class, times(1)).withArguments(anyString(), eq("RecurringAppointments"), any(Date.class), any(URI.class), eq(String.format("/openmrs/ws/rest/v1/recurring-appointments?uuid=%s", anotherUuid)), eq("appointments"));
+        verifyNew(Event.class, times(1)).withArguments(anyString(), eq("RecurringAppointments"), any(LocalDateTime.class), nullable(URI.class), eq(String.format("/openmrs/ws/rest/v1/recurring-appointments?uuid=%s", UUID)), eq("appointments"));
+        verifyNew(Event.class, times(1)).withArguments(anyString(), eq("RecurringAppointments"), any(LocalDateTime.class), nullable(URI.class), eq(String.format("/openmrs/ws/rest/v1/recurring-appointments?uuid=%s", anotherUuid)), eq("appointments"));
         verify(administrationService, times(2)).getGlobalProperty(RAISE_EVENT_GLOBAL_PROPERTY);
         verify(administrationService, times(2)).getGlobalProperty(URL_PATTERN_GLOBAL_PROPERTY, DEFAULT_URL_PATTERN);
     }
@@ -183,8 +187,8 @@ public class RecurringAppointmentsAdviceTest {
 
         verify(eventService, times(2)).notify(any(Event.class));
         verify(atomFeedSpringTransactionManager, times(2)).executeWithTransaction(any(AFTransactionWorkWithoutResult.class));
-        verifyNew(Event.class, times(1)).withArguments(anyString(), eq("RecurringAppointments"), any(Date.class), any(URI.class), eq(String.format("/openmrs/ws/rest/v1/recurring-appointments?uuid=%s", UUID)), eq("appointments"));
-        verifyNew(Event.class, times(1)).withArguments(anyString(), eq("RecurringAppointments"), any(Date.class), any(URI.class), eq(String.format("/openmrs/ws/rest/v1/recurring-appointments?uuid=%s", anotherUuid)), eq("appointments"));
+        verifyNew(Event.class, times(1)).withArguments(anyString(), eq("RecurringAppointments"), any(LocalDateTime.class), nullable(URI.class), eq(String.format("/openmrs/ws/rest/v1/recurring-appointments?uuid=%s", UUID)), eq("appointments"));
+        verifyNew(Event.class, times(1)).withArguments(anyString(), eq("RecurringAppointments"), any(LocalDateTime.class), nullable(URI.class), eq(String.format("/openmrs/ws/rest/v1/recurring-appointments?uuid=%s", anotherUuid)), eq("appointments"));
         verify(administrationService, times(2)).getGlobalProperty(RAISE_EVENT_GLOBAL_PROPERTY);
         verify(administrationService, times(2)).getGlobalProperty(URL_PATTERN_GLOBAL_PROPERTY, DEFAULT_URL_PATTERN);
     }
@@ -200,8 +204,8 @@ public class RecurringAppointmentsAdviceTest {
 
         verify(eventService, times(2)).notify(any(Event.class));
         verify(atomFeedSpringTransactionManager, times(2)).executeWithTransaction(any(AFTransactionWorkWithoutResult.class));
-        verifyNew(Event.class, times(1)).withArguments(anyString(), eq("RecurringAppointments"), any(Date.class), any(URI.class), eq(String.format("/openmrs/ws/rest/v1/recurring-appointments?uuid=%s", UUID)), eq("appointments"));
-        verifyNew(Event.class, times(1)).withArguments(anyString(), eq("RecurringAppointments"), any(Date.class), any(URI.class), eq(String.format("/openmrs/ws/rest/v1/recurring-appointments?uuid=%s", anotherUuid)), eq("appointments"));
+        verifyNew(Event.class, times(1)).withArguments(anyString(), eq("RecurringAppointments"), any(LocalDateTime.class), nullable(URI.class), eq(String.format("/openmrs/ws/rest/v1/recurring-appointments?uuid=%s", UUID)), eq("appointments"));
+        verifyNew(Event.class, times(1)).withArguments(anyString(), eq("RecurringAppointments"), any(LocalDateTime.class), nullable(URI.class), eq(String.format("/openmrs/ws/rest/v1/recurring-appointments?uuid=%s", anotherUuid)), eq("appointments"));
         verify(administrationService, times(2)).getGlobalProperty(RAISE_EVENT_GLOBAL_PROPERTY);
         verify(administrationService, times(2)).getGlobalProperty(URL_PATTERN_GLOBAL_PROPERTY, DEFAULT_URL_PATTERN);
     }

--- a/omod/pom.xml
+++ b/omod/pom.xml
@@ -17,7 +17,7 @@
 		<MODULE_NAME>${project.name}</MODULE_NAME>
 		<MODULE_VERSION>${project.version}</MODULE_VERSION>
 		<MODULE_PACKAGE>${project.groupId}.${MODULE_ID}</MODULE_PACKAGE>
-		<openmrs.platform.version>2.1.6</openmrs.platform.version>
+		<openmrs.platform.version>2.4.2</openmrs.platform.version>
 	</properties>
 
 	<dependencies>

--- a/omod/src/test/java/org/openmrs/module/appointments/web/BaseWebControllerTest.java
+++ b/omod/src/test/java/org/openmrs/module/appointments/web/BaseWebControllerTest.java
@@ -10,8 +10,8 @@ import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.servlet.HandlerExecutionChain;
-import org.springframework.web.servlet.mvc.annotation.AnnotationMethodHandlerAdapter;
-import org.springframework.web.servlet.mvc.annotation.DefaultAnnotationHandlerMapping;
+import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter;
+import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
 
 import javax.servlet.http.HttpServletRequest;
 import java.util.List;
@@ -22,10 +22,10 @@ import java.util.Map;
 public class BaseWebControllerTest extends BaseModuleWebContextSensitiveTest {
 
     @Autowired
-    private AnnotationMethodHandlerAdapter handlerAdapter;
+    private RequestMappingHandlerAdapter handlerAdapter;
 
     @Autowired
-    private List<DefaultAnnotationHandlerMapping> handlerMappings;
+    private List<RequestMappingHandlerMapping> handlerMappings;
 
     private ObjectMapper objectMapper = new ObjectMapper();
 
@@ -134,7 +134,7 @@ public class BaseWebControllerTest extends BaseModuleWebContextSensitiveTest {
         MockHttpServletResponse response = new MockHttpServletResponse();
 
         HandlerExecutionChain handlerExecutionChain = null;
-        for (DefaultAnnotationHandlerMapping handlerMapping : handlerMappings) {
+        for (RequestMappingHandlerMapping handlerMapping : handlerMappings) {
             handlerExecutionChain = handlerMapping.getHandler(request);
             if (handlerExecutionChain != null) {
                 break;

--- a/omod/src/test/java/org/openmrs/module/appointments/web/controller/AppointmentServiceControllerIT.java
+++ b/omod/src/test/java/org/openmrs/module/appointments/web/controller/AppointmentServiceControllerIT.java
@@ -57,8 +57,8 @@ public class AppointmentServiceControllerIT extends BaseIntegrationTest {
         assertEquals("Cardiology Consultation", asResponse.get("name"));
         assertEquals("09:00:00", asResponse.get("startTime"));
         assertEquals("17:30:00", asResponse.get("endTime"));
-        assertEquals(30, asResponse.get("durationMins"));
-        assertEquals(30, asResponse.get("maxAppointmentsLimit"));
+        assertEquals(30, (int) asResponse.get("durationMins"));
+        assertEquals(30, (int) asResponse.get("maxAppointmentsLimit"));
         assertEquals("#00ff00", asResponse.get("color"));
         assertNotNull(asResponse.get("weeklyAvailability"));
         assertEquals(0, ((ArrayList)asResponse.get("weeklyAvailability")).size());
@@ -97,8 +97,8 @@ public class AppointmentServiceControllerIT extends BaseIntegrationTest {
         assertEquals("Cardiology Consultation", asResponse.get("name"));
         assertEquals("09:00:00", asResponse.get("startTime"));
         assertEquals("17:30:00", asResponse.get("endTime"));
-        assertEquals(30, asResponse.get("durationMins"));
-        assertEquals(30, asResponse.get("maxAppointmentsLimit"));
+        assertEquals(30, (int)asResponse.get("durationMins"));
+        assertEquals(30, (int)asResponse.get("maxAppointmentsLimit"));
         assertEquals("#0000ff", asResponse.get("color"));
         ArrayList weeklyAvailabilities = (ArrayList) asResponse.get("weeklyAvailability");
         assertNotNull(weeklyAvailabilities);

--- a/omod/src/test/java/org/openmrs/module/appointments/web/controller/AppointmentServiceDefinitionControllerTest.java
+++ b/omod/src/test/java/org/openmrs/module/appointments/web/controller/AppointmentServiceDefinitionControllerTest.java
@@ -63,7 +63,7 @@ public class AppointmentServiceDefinitionControllerTest {
         verify(appointmentServiceMapper, times(1)).constructResponse(mappedServicePayload);
         assertNotNull(savedAppointmentService);
         assertEquals(response, savedAppointmentService.getBody());
-        assertEquals("200", savedAppointmentService.getStatusCode().toString());
+        assertEquals(200, savedAppointmentService.getStatusCode().value());
     }
 
     @Test
@@ -87,7 +87,7 @@ public class AppointmentServiceDefinitionControllerTest {
         ResponseEntity<Object> appointmentService = appointmentServiceController.defineAppointmentService(appointmentServiceDescription);
 
         assertNotNull(appointmentService);
-        assertEquals("400", appointmentService.getStatusCode().toString());
+        assertEquals(400, appointmentService.getStatusCode().value());
         assertEquals("The service 'Cardio' is already present", ((RuntimeException)appointmentService.getBody()).getMessage());
     }
 

--- a/omod/src/test/java/org/openmrs/module/appointments/web/controller/AppointmentsControllerIT.java
+++ b/omod/src/test/java/org/openmrs/module/appointments/web/controller/AppointmentsControllerIT.java
@@ -3,7 +3,6 @@ package org.openmrs.module.appointments.web.controller;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.codehaus.jackson.type.TypeReference;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;

--- a/omod/src/test/java/org/openmrs/module/appointments/web/controller/RecurringAppointmentsControllerTest.java
+++ b/omod/src/test/java/org/openmrs/module/appointments/web/controller/RecurringAppointmentsControllerTest.java
@@ -140,7 +140,7 @@ public class RecurringAppointmentsControllerTest {
         verify(recurringAppointmentsService, never()).generateRecurringAppointments(recurringAppointmentRequest);
         verify(recurringAppointmentMapper, never()).constructResponse(Collections.emptyList());
         assertEquals(responseEntity.getStatusCode(), HttpStatus.BAD_REQUEST);
-        assertEquals(((Map) ((Map) responseEntity.getBody()).get("error")).get("message"), "save error");
+        assertEquals(((Map) ((Map) responseEntity.getBody()).get("error")).get("message"), "save error [save error]");
     }
 
     @Test
@@ -213,7 +213,7 @@ public class RecurringAppointmentsControllerTest {
         verify(appointmentRecurringPatternService, never()).validateAndSave(any());
         verify(recurringAppointmentMapper, never()).constructResponse(Collections.emptyList());
         assertEquals(responseEntity.getStatusCode(), HttpStatus.BAD_REQUEST);
-        assertEquals(((Map) ((Map) responseEntity.getBody()).get("error")).get("message"), "some error");
+        assertEquals(((Map) ((Map) responseEntity.getBody()).get("error")).get("message"), "some error [some error]");
     }
 
     private void updateErrorsObject() {
@@ -274,7 +274,7 @@ public class RecurringAppointmentsControllerTest {
         ResponseEntity<Object> responseEntity = recurringAppointmentsController.transitionAppointment("appointmentUuid", statusDetails);
         Mockito.verify(appointmentRecurringPatternService, never()).changeStatus(any(),any(), any());
         assertEquals(HttpStatus.BAD_REQUEST, responseEntity.getStatusCode());
-        assertEquals(((Map)((Map)responseEntity.getBody()).get("error")).get("message"), "Time Zone is missing");
+        assertEquals(((Map)((Map)responseEntity.getBody()).get("error")).get("message"), "Time Zone is missing [Time Zone is missing]");
     }
 
     @Test
@@ -287,7 +287,7 @@ public class RecurringAppointmentsControllerTest {
         ResponseEntity<Object> responseEntity = recurringAppointmentsController.transitionAppointment("appointmentUuid", statusDetails);
         Mockito.verify(appointmentRecurringPatternService, never()).changeStatus(any(),any(), any());
         assertEquals(HttpStatus.BAD_REQUEST, responseEntity.getStatusCode());
-        assertEquals(((Map)((Map)responseEntity.getBody()).get("error")).get("message"), "Appointment does not exist");
+        assertEquals(((Map)((Map)responseEntity.getBody()).get("error")).get("message"), "Appointment does not exist [Appointment does not exist]");
     }
 
     @Test
@@ -299,7 +299,7 @@ public class RecurringAppointmentsControllerTest {
         verify(appointmentMapper, never()).constructConflictResponse(Collections.emptyMap());
         verify(recurringAppointmentsService, never()).generateRecurringAppointments(any());
         assertEquals(responseEntity.getStatusCode(), HttpStatus.INTERNAL_SERVER_ERROR);
-        assertEquals(((Map) ((Map) responseEntity.getBody()).get("error")).get("message"), "some error");
+        assertEquals(((Map) ((Map) responseEntity.getBody()).get("error")).get("message"), "some error [some error]");
     }
 
     @Test

--- a/omod/src/test/java/org/openmrs/module/appointments/web/mapper/AppointmentMapperTest.java
+++ b/omod/src/test/java/org/openmrs/module/appointments/web/mapper/AppointmentMapperTest.java
@@ -34,6 +34,7 @@ import org.openmrs.module.appointments.web.contract.AppointmentQuery;
 import org.openmrs.module.appointments.web.contract.AppointmentRequest;
 import org.openmrs.module.appointments.web.contract.AppointmentServiceDefaultResponse;
 import org.openmrs.module.appointments.web.extension.AppointmentResponseExtension;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.text.ParseException;
@@ -59,6 +60,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.powermock.api.mockito.PowerMockito.when;
 
+@PowerMockIgnore("javax.management.*")
 @RunWith(PowerMockRunner.class)
 public class AppointmentMapperTest {
 

--- a/omod/src/test/java/org/openmrs/module/appointments/web/mapper/AppointmentServiceDefinitionMapperTest.java
+++ b/omod/src/test/java/org/openmrs/module/appointments/web/mapper/AppointmentServiceDefinitionMapperTest.java
@@ -18,6 +18,7 @@ import org.openmrs.module.appointments.service.AppointmentServiceDefinitionServi
 import org.openmrs.module.appointments.service.SpecialityService;
 import org.openmrs.module.appointments.web.contract.*;
 import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
@@ -30,6 +31,7 @@ import static org.junit.Assert.*;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 import static org.powermock.api.mockito.PowerMockito.when;
 
+@PowerMockIgnore("javax.management.*")
 @PrepareForTest(Context.class)
 @RunWith(PowerMockRunner.class)
 public class AppointmentServiceDefinitionMapperTest {

--- a/omod/src/test/java/org/openmrs/module/appointments/web/mapper/RecurringAppointmentMapperTest.java
+++ b/omod/src/test/java/org/openmrs/module/appointments/web/mapper/RecurringAppointmentMapperTest.java
@@ -22,6 +22,7 @@ import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -62,7 +63,7 @@ public class RecurringAppointmentMapperTest {
                 .withEndDateTime(DateUtils.addDays(new Date(), 2))
                 .build();
         when(appointmentMapper.constructResponse(any(Appointment.class))).thenReturn(new AppointmentDefaultResponse());
-        when(recurringPatternMapper.mapToResponse(any(AppointmentRecurringPattern.class))).thenReturn(recurringPattern);
+        when(recurringPatternMapper.mapToResponse(nullable(AppointmentRecurringPattern.class))).thenReturn(recurringPattern);
 
         List<RecurringAppointmentDefaultResponse> recurringAppointmentDefaultResponses =
                 recurringAppointmentMapper.constructResponse(Arrays.asList(appointmentOne, appointmentTwo, appointmentThree));
@@ -103,7 +104,7 @@ public class RecurringAppointmentMapperTest {
                 .withEndDateTime(new SimpleDateFormat("dd/MM/yyyy").parse("18/06/2019"))
                 .build();
         when(appointmentMapper.constructResponse(any(Appointment.class))).thenReturn(new AppointmentDefaultResponse());
-        when(recurringPatternMapper.mapToResponse(any(AppointmentRecurringPattern.class))).thenReturn(recurringPattern);
+        when(recurringPatternMapper.mapToResponse(nullable(AppointmentRecurringPattern.class))).thenReturn(recurringPattern);
 
         List<RecurringAppointmentDefaultResponse> recurringAppointmentDefaultResponses =
                 recurringAppointmentMapper.constructResponse(Arrays.asList(appointmentOne, appointmentTwo));
@@ -136,7 +137,7 @@ public class RecurringAppointmentMapperTest {
                 .withEndDateTime(new SimpleDateFormat("dd/MM/yyyy").parse("17/06/2019"))
                 .build();
         when(appointmentMapper.constructResponse(any(Appointment.class))).thenReturn(new AppointmentDefaultResponse());
-        when(recurringPatternMapper.mapToResponse(any(AppointmentRecurringPattern.class))).thenReturn(recurringPattern);
+        when(recurringPatternMapper.mapToResponse(nullable(AppointmentRecurringPattern.class))).thenReturn(recurringPattern);
 
         List<RecurringAppointmentDefaultResponse> recurringAppointmentDefaultResponses =
                 recurringAppointmentMapper.constructResponse(Arrays.asList(appointmentOne));
@@ -148,6 +149,6 @@ public class RecurringAppointmentMapperTest {
                 recurringAppointmentDefaultResponses.get(0).getRecurringPattern().getDaysOfWeek());
         assertNull(recurringAppointmentDefaultResponses.get(0).getRecurringPattern().getEndDate());
         verify(appointmentMapper).constructResponse(any(Appointment.class));
-        verify(recurringPatternMapper).mapToResponse(any(AppointmentRecurringPattern.class));
+        verify(recurringPatternMapper).mapToResponse(nullable(AppointmentRecurringPattern.class));
     }
 }

--- a/omod/src/test/java/org/openmrs/module/appointments/web/service/impl/AllAppointmentRecurringPatternUpdateServiceTest.java
+++ b/omod/src/test/java/org/openmrs/module/appointments/web/service/impl/AllAppointmentRecurringPatternUpdateServiceTest.java
@@ -54,8 +54,10 @@ import org.openmrs.module.appointments.web.contract.RecurringPattern;
 import org.openmrs.module.appointments.web.mapper.AppointmentMapper;
 import org.openmrs.module.appointments.web.mapper.RecurringPatternMapper;
 import org.openmrs.module.appointments.web.util.AppointmentBuilder;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.modules.junit4.PowerMockRunner;
 
+@PowerMockIgnore("javax.management.*")
 @RunWith(PowerMockRunner.class)
 public class AllAppointmentRecurringPatternUpdateServiceTest {
     @Mock

--- a/omod/src/test/java/org/openmrs/module/appointments/web/service/impl/SingleAppointmentRecurringPatternUpdateServiceTest.java
+++ b/omod/src/test/java/org/openmrs/module/appointments/web/service/impl/SingleAppointmentRecurringPatternUpdateServiceTest.java
@@ -11,6 +11,7 @@ import org.openmrs.module.appointments.service.AppointmentsService;
 import org.openmrs.module.appointments.web.contract.AppointmentRequest;
 import org.openmrs.module.appointments.web.contract.RecurringAppointmentRequest;
 import org.openmrs.module.appointments.web.mapper.AppointmentMapper;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.util.Collections;
@@ -25,6 +26,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+@PowerMockIgnore("javax.management.*")
 @RunWith(PowerMockRunner.class)
 public class SingleAppointmentRecurringPatternUpdateServiceTest {
 

--- a/omod/src/test/resources/TestingApplicationContext.xml
+++ b/omod/src/test/resources/TestingApplicationContext.xml
@@ -20,6 +20,11 @@
 				<value>classpath:test-hibernate.cfg.xml</value>
 			</list>
 		</property>
+		<property name="packagesToScan">
+			<list>
+				<value>org.openmrs</value>
+			</list>
+		</property>
 		<property name="mappingJarLocations">
 			<ref bean="mappingJarResources" />
 		</property>

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
 		<mockitoVersion>3.5.11</mockitoVersion>
 		<argLine>-Xmx1024m</argLine>
 		<jacocoVersion>0.7.9</jacocoVersion>
-		<openmrsAtomfeedVersion>2.6.1</openmrsAtomfeedVersion>
+		<openmrsAtomfeedVersion>2.6.2-SNAPSHOT</openmrsAtomfeedVersion>
 		<atomfeed.version>1.10.1</atomfeed.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -37,12 +37,12 @@
     </modules>
 
 	<properties>
-		<openmrs.platform.version>2.1.6</openmrs.platform.version>
+		<openmrs.platform.version>2.4.2</openmrs.platform.version>
 		<!--test dependencies-->
-		<junitVersion>4.12</junitVersion>
-		<powerMockVersion>1.6.5</powerMockVersion>
-		<hamcrestVersion>1.3</hamcrestVersion>
-		<mockitoVersion>1.10.19</mockitoVersion>
+		<junitVersion>4.13</junitVersion>
+		<powerMockVersion>2.0.7</powerMockVersion>
+		<hamcrestVersion>2.2</hamcrestVersion>
+		<mockitoVersion>3.5.11</mockitoVersion>
 		<argLine>-Xmx1024m</argLine>
 		<jacocoVersion>0.7.9</jacocoVersion>
 		<openmrsAtomfeedVersion>2.6.1</openmrsAtomfeedVersion>
@@ -141,7 +141,7 @@
 
 			<dependency>
 				<groupId>org.powermock</groupId>
-				<artifactId>powermock-api-mockito</artifactId>
+				<artifactId>powermock-api-mockito2</artifactId>
 				<version>${powerMockVersion}</version>
 				<scope>test</scope>
 			</dependency>
@@ -177,13 +177,13 @@
 			<dependency>
 				<groupId>org.openmrs.module</groupId>
 				<artifactId>webservices.rest-omod</artifactId>
-				<version>2.12</version>
+				<version>2.29.0</version>
 				<scope>provided</scope>
 			</dependency>
 			<dependency>
 				<groupId>org.openmrs.module</groupId>
 				<artifactId>webservices.rest-omod-common</artifactId>
-				<version>2.12</version>
+				<version>2.29.0</version>
 				<scope>provided</scope>
 			</dependency>
 			<dependency>
@@ -220,7 +220,7 @@
 			</dependency>
 			<dependency>
 				<groupId>org.mockito</groupId>
-				<artifactId>mockito-all</artifactId>
+				<artifactId>mockito-core</artifactId>
 				<version>${mockitoVersion}</version>
 				<exclusions>
 					<exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -47,8 +47,8 @@
 		<jacocoVersion>0.7.9</jacocoVersion>
 		<openmrsAtomfeedVersion>2.6.2-SNAPSHOT</openmrsAtomfeedVersion>
 		<atomfeed.version>1.10.1</atomfeed.version>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+		<javaxMail.version>1.6.2</javaxMail.version>
+		<webServices.version>2.29.0</webServices.version>
 	</properties>
 
 	<build>
@@ -177,13 +177,13 @@
 			<dependency>
 				<groupId>org.openmrs.module</groupId>
 				<artifactId>webservices.rest-omod</artifactId>
-				<version>2.29.0</version>
+				<version>${webServices.version}</version>
 				<scope>provided</scope>
 			</dependency>
 			<dependency>
 				<groupId>org.openmrs.module</groupId>
 				<artifactId>webservices.rest-omod-common</artifactId>
-				<version>2.29.0</version>
+				<version>${webServices.version}</version>
 				<scope>provided</scope>
 			</dependency>
 			<dependency>


### PR DESCRIPTION
This PR is about:

- Upgrading below with OMRS 2.4.2 upgrade
   - openmrs to 2.4.2
   - openMRSWebServicesVersion to 2.29.0
   - javaxServletVersion to 4.0.1
   - junit to 4.13
   - powerMockVersion to 2.0.7
   - hamcrestVersion to 2.2
   - openmrsAtomfeedVersion to 2.6.2-SNAPSHOT
   - javaxMailVersion to 1.6.2
   - webServicesVersion to 2.29.0
   
- Resolves failing test cases