### PR TITLE
Backend migration to create dateless appointments

### DIFF
--- a/api/src/main/java/org/openmrs/module/appointments/helper/AppointmentServiceHelper.java
+++ b/api/src/main/java/org/openmrs/module/appointments/helper/AppointmentServiceHelper.java
@@ -51,8 +51,10 @@ public class AppointmentServiceHelper {
         appointmentJson.put("providerUuid", providerUuid);
         String locationUuid = appointment.getLocation() != null ? appointment.getLocation().getUuid() : null;
         appointmentJson.put("locationUuid", locationUuid);
-        appointmentJson.put("startDateTime", appointment.getStartDateTime().toInstant().toString());
-        appointmentJson.put("endDateTime", appointment.getEndDateTime().toInstant().toString());
+        String startDate = appointment.getStartDateTime() != null ? appointment.getStartDateTime().toInstant().toString() : null;
+        appointmentJson.put("startDateTime", startDate);
+        String endDate = appointment.getEndDateTime() != null ? appointment.getEndDateTime().toInstant().toString() : null;
+        appointmentJson.put("endDateTime", endDate);
         appointmentJson.put("appointmentKind", appointment.getAppointmentKind().name());
         appointmentJson.put("appointmentNotes", appointment.getComments());
         ObjectMapper mapperObj = new ObjectMapper();

--- a/api/src/main/resources/liquibase.xml
+++ b/api/src/main/resources/liquibase.xml
@@ -655,4 +655,16 @@
             ALTER TABLE patient_appointment_provider MODIFY voided TINYINT(1) DEFAULT 0;
         </sql>
     </changeSet>
+    <changeSet id="remove-not-null-constraint-202304211826" author="Kavitha, Umair">
+        <preConditions onFail="MARK_RAN">
+            <tableExists tableName="patient_appointment" />
+            <columnExists tableName="patient_appointment" columnName="start_date_time" />
+            <columnExists tableName="patient_appointment" columnName="end_date_time" />
+        </preConditions>
+        <comment>Update start and end date time of patient appointment table to be nullable</comment>
+        <sql>
+            ALTER TABLE patient_appointment MODIFY start_date_time datetime;
+            ALTER TABLE patient_appointment MODIFY end_date_time datetime;
+        </sql>
+    </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
Database table alteration to update appointment's start and end date time to be nullable
Accept null values for start and end date times while creating appointments