### PR TITLE
Adding locked status for appointment

### DIFF
--- a/api/src/main/java/org/openmrs/module/appointments/model/AppointmentStatus.java
+++ b/api/src/main/java/org/openmrs/module/appointments/model/AppointmentStatus.java
@@ -1,7 +1,7 @@
 package org.openmrs.module.appointments.model;
 
 public enum AppointmentStatus {
-    Requested("Requested", 0), Scheduled("Scheduled", 1), CheckedIn("CheckedIn", 2), Completed("Completed", 3), Cancelled("Cancelled", 3), Missed("Missed", 3);
+    Requested("Requested", 0), Scheduled("Scheduled", 1), CheckedIn("CheckedIn", 2), Completed("Completed", 3), Cancelled("Cancelled", 3), Missed("Missed", 3), Locked("Locked", 1);
 
     private final String value;
     private final int sequence;


### PR DESCRIPTION
Adding locked status for appointment. 
We need locked status as an intermediate later to book an appointment for a patient who would like to do an online payment. 
Once the payment is successful, the appointment can be marked as Scheduled. 