### PR TITLE
BAH-3522 | Add. UTC Time Slots To Appointments Read Query

### DIFF
--- a/api/src/main/resources/liquibase.xml
+++ b/api/src/main/resources/liquibase.xml
@@ -371,6 +371,14 @@
         <sqlFile path="patientPastAppointments_v2.sql"/>
     </changeSet>
 
+    <changeSet id="global-property-past-appointments-sql-202402211800" author="Bahmni" runOnChange="true">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="1">select count(*) from global_property where property='bahmni.sqlGet.pastAppointments'</sqlCheck>
+        </preConditions>
+        <comment>Updating query to fetch past appointments for patient</comment>
+        <sqlFile path="patientPastAppointments_v3.sql"/>
+    </changeSet>
+
     <changeSet id="global-property-upcoming-appointments-sql-09022021" author="Maharjun, Shireesha" runOnChange="true">
         <preConditions onFail="MARK_RAN">
             <sqlCheck expectedResult="0">select count(*) from global_property where property='bahmni.sqlGet.upComingAppointments'</sqlCheck>
@@ -385,6 +393,14 @@
         </preConditions>
         <comment>Updating query to fetch upcoming appointments for patient</comment>
         <sqlFile path="patientUpcomingAppointments_v2.sql"/>
+    </changeSet>
+
+    <changeSet id="global-property-upcoming-appointments-sql-202402211805" author="Bahmni" runOnChange="true">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="1">select count(*) from global_property where property='bahmni.sqlGet.upComingAppointments'</sqlCheck>
+        </preConditions>
+        <comment>Updating query to fetch upcoming appointments for patient</comment>
+        <sqlFile path="patientUpcomingAppointments_v3.sql"/>
     </changeSet>
 
     <changeSet id="Create-Available-for-appointments-201712121212-2" author="Maharjun, Saikumar">

--- a/api/src/main/resources/patientPastAppointments_v3.sql
+++ b/api/src/main/resources/patientPastAppointments_v3.sql
@@ -1,0 +1,24 @@
+UPDATE global_property
+SET property_value= 'SELECT
+     app_service.name                                                                                           AS `DASHBOARD_APPOINTMENTS_SERVICE_KEY`,
+     app_service_type.name                                                                                      AS `DASHBOARD_APPOINTMENTS_SERVICE_TYPE_KEY`,
+     DATE_FORMAT(pa.start_date_time, "%d/%m/%Y")                                                                AS `DASHBOARD_APPOINTMENTS_DATE_KEY`,
+     CONCAT(DATE_FORMAT(pa.start_date_time, "%l:%i %p"), " - ", DATE_FORMAT(pa.end_date_time, "%l:%i %p"))      AS `DASHBOARD_APPOINTMENTS_SLOT_KEY`,
+     CONCAT(pn.given_name, " ", pn.family_name)                                                                 AS `DASHBOARD_APPOINTMENTS_PROVIDER_KEY`,
+     pa.status                                                                                                  AS `DASHBOARD_APPOINTMENTS_STATUS_KEY`,
+     CONVERT_TZ(pa.start_date_time,  @@session.time_zone, "UTC")                                                AS `DASHBOARD_APPOINTMENTS_START_DATE_IN_UTC_KEY`,
+     CONVERT_TZ(pa.end_date_time, @@session.time_zone, "UTC")                                                   AS `DASHBOARD_APPOINTMENTS_END_DATE_IN_UTC_KEY`
+FROM
+patient_appointment pa
+JOIN person p ON p.person_id = pa.patient_id AND pa.voided IS FALSE
+JOIN appointment_service app_service
+ ON app_service.appointment_service_id = pa.appointment_service_id AND app_service.voided IS FALSE
+LEFT JOIN patient_appointment_provider pap on pa.patient_appointment_id = pap.patient_appointment_id AND (pap.voided=0 OR pap.voided IS NULL)
+LEFT JOIN provider prov ON prov.provider_id = pap.provider_id AND prov.retired IS FALSE
+LEFT JOIN person_name pn ON pn.person_id = prov.person_id AND pn.voided IS FALSE
+LEFT JOIN appointment_service_type app_service_type
+ ON app_service_type.appointment_service_type_id = pa.appointment_service_type_id
+WHERE p.uuid = ${patientUuid} AND pa.start_date_time < CURDATE() AND (app_service_type.voided IS FALSE OR app_service_type.voided IS NULL)
+ORDER BY pa.start_date_time DESC
+LIMIT 5;'
+WHERE property = 'bahmni.sqlGet.pastAppointments';

--- a/api/src/main/resources/patientUpcomingAppointments_v3.sql
+++ b/api/src/main/resources/patientUpcomingAppointments_v3.sql
@@ -1,0 +1,30 @@
+UPDATE global_property
+SET property_value = 'SELECT
+  pa.uuid,
+  app_service.name                                                                                      AS `DASHBOARD_APPOINTMENTS_SERVICE_KEY`,
+  app_service_type.name                                                                                 AS `DASHBOARD_APPOINTMENTS_SERVICE_TYPE_KEY`,
+  DATE_FORMAT(pa.start_date_time, "%d/%m/%Y")                                                           AS `DASHBOARD_APPOINTMENTS_DATE_KEY`,
+  CONCAT(DATE_FORMAT(pa.start_date_time, "%l:%i %p"), " - ", DATE_FORMAT(pa.end_date_time, "%l:%i %p")) AS `DASHBOARD_APPOINTMENTS_SLOT_KEY`,
+  CONCAT(pn.given_name, " ", pn.family_name)                                                            AS `DASHBOARD_APPOINTMENTS_PROVIDER_KEY`,
+  CONVERT_TZ(pa.start_date_time, @@session.time_zone, "UTC")                                            AS `DASHBOARD_APPOINTMENTS_START_DATE_IN_UTC_KEY`,
+  CONVERT_TZ(pa.end_date_time, @@session.time_zone, "UTC")                                              AS `DASHBOARD_APPOINTMENTS_END_DATE_IN_UTC_KEY`,
+  pa.status                                                                                             AS `DASHBOARD_APPOINTMENTS_STATUS_KEY`,
+  pa.appointment_kind                                                                                   AS `DASHBOARD_APPOINTMENTS_KIND`,
+  pa.start_date_time                                                                                    AS `DASHBOARD_APPOINTMENTS_START_DATE_KEY`,
+  pa.end_date_time                                                                                      AS `DASHBOARD_APPOINTMENTS_END_DATE_KEY`,
+  pa.tele_health_video_link
+FROM
+  patient_appointment pa
+  JOIN person p ON p.person_id = pa.patient_id AND pa.voided IS FALSE
+  JOIN appointment_service app_service
+    ON app_service.appointment_service_id = pa.appointment_service_id AND app_service.voided IS FALSE
+  LEFT JOIN patient_appointment_provider pap on pa.patient_appointment_id = pap.patient_appointment_id AND (pap.voided=0 OR pap.voided IS NULL)
+  LEFT JOIN provider prov ON prov.provider_id = pap.provider_id AND prov.retired IS FALSE
+  LEFT JOIN person_name pn ON pn.person_id = prov.person_id AND pn.voided IS FALSE
+  LEFT JOIN appointment_service_type app_service_type
+    ON app_service_type.appointment_service_type_id = pa.appointment_service_type_id
+WHERE p.uuid = ${patientUuid} AND
+      pa.start_date_time >= CURDATE() AND
+      (app_service_type.voided IS FALSE OR app_service_type.voided IS NULL)
+ORDER BY pa.start_date_time ASC;'
+WHERE property='bahmni.sqlGet.upComingAppointments';


### PR DESCRIPTION
PR -> [BAH-3522](https://bahmni.atlassian.net/browse/BAH-3522)

This PR updates the query for retrieving past and upcoming appointments, ensuring that time slots (appointment start and end datetime) are first converted to UTC from the server timezone before being sent along with the payload. Additionally, a liquibase change for the appointment query to be updated has been included.