### PR TITLE
BAH-4098 | Fix. Conditional resource jar file name to be appointments atomfeed

### DIFF
--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -24,7 +24,7 @@
 
 	<conditional_resources>
 		<conditionalResource>
-			<path>/lib/fhir2-api-2.1-${project.parent.version}.jar</path>
+			<path>/lib/appointments-atom-feed-${project.parent.version}.jar</path>
 			<modules>
 				<module>
 					<moduleId>org.ict4h.openmrs.openmrs-atomfeed</moduleId>


### PR DESCRIPTION
This PR is a fix for https://github.com/Bahmni/openmrs-module-appointments/pull/74 where incorrect conditional resource was mapped. So fixing it with appointments-atom-feed.jar