### PR TITLE
O3-4434: Handle APIAuthenticationException in the openmrs-module-appointments

### DIFF
--- a/api/src/main/java/org/openmrs/module/appointments/events/eventListener/AppointmentSMSEventListener.java
+++ b/api/src/main/java/org/openmrs/module/appointments/events/eventListener/AppointmentSMSEventListener.java
@@ -13,6 +13,7 @@ import org.openmrs.module.appointments.service.AppointmentArgumentsMapper;
 import org.openmrs.module.appointments.model.Appointment;
 import org.openmrs.module.appointments.events.AppointmentBookingEvent;
 import org.openmrs.module.appointments.events.RecurringAppointmentEvent;
+import org.openmrs.util.PrivilegeConstants;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
@@ -82,7 +83,12 @@ public class AppointmentSMSEventListener {
     }
     private boolean shouldSendEmailForBookingAppointment() {
         AdministrationService administrationService = Context.getService(AdministrationService.class);
-        return Boolean.parseBoolean(administrationService.getGlobalProperty("sms.enableAppointmentBookingSMSAlert", "false"));
+        try {
+            Context.getUserContext().addProxyPrivilege(PrivilegeConstants.GET_GLOBAL_PROPERTIES);
+            return Boolean.parseBoolean(administrationService.getGlobalProperty("sms.enableAppointmentBookingSMSAlert", "false"));
+        } finally {
+            Context.getUserContext().removeProxyPrivilege(PrivilegeConstants.GET_GLOBAL_PROPERTIES);
+        }
     }
     private String getPhoneNumber(Patient patient) {
         PersonAttribute phoneNumber = patient.getAttribute("phoneNumber");


### PR DESCRIPTION
Starting from OpenMRS Platform 2.7.0, users must have the Get Global Properties privilege to access global properties. As a result, running this module with Platform 2.7.0 during installation triggers multiple APIAuthenticationExceptions.

This update grants a proxy privilege to the shouldSendEmailForBookingAppointment method to resolve the issue.

- Ticket: [O3-4434](https://openmrs.atlassian.net/browse/O3-4434)
- Reference: [TRUNK-6203](https://openmrs.atlassian.net/browse/TRUNK-6203)