### PR TITLE
Hardcode Email person attribute type UUID

### DIFF
--- a/api/src/main/resources/liquibase.xml
+++ b/api/src/main/resources/liquibase.xml
@@ -645,7 +645,7 @@
         </preConditions>
         <comment> Add email address in registration page </comment>
         <sql>
-            INSERT INTO person_attribute_type (name, description, format, searchable, creator, date_created, retired, uuid) VALUES ('email', 'Email Address', 'java.lang.String', '1', 1, now(), 0, uuid());
+            INSERT INTO person_attribute_type (name, description, format, searchable, creator, date_created, retired, uuid) VALUES ('email', 'Email Address', 'java.lang.String', '1', 1, now(), 0, '770943ca-b8bb-4f5d-9cdc-48beff86f62b');
         </sql>
     </changeSet>
     <changeSet id="create-column-tele_health_video_link-202106211857" author="Angshu">


### PR DESCRIPTION
As raised in this Slack message:
https://openmrs.slack.com/archives/C02UNMKFH8V/p1739811381737209

>server comes with some person attributes types by default.
One of which is email . Its UUID is 1efce44e-ecc3-11ef-ac98-0242ac170003 . Would someone know how this PAT is created in the first place?

> `uuid()` [function] suggests that the UUID is autogenerated, which is not ideal, as it does not give implementers control over this PAT (example, to rename it, void it...) because the UUID might be changing on new instances.