### PR TITLE
BAH-3847: Appointments: Add REST support for 'fulfilling encounters'

### DIFF
--- a/omod/src/main/java/org/openmrs/module/appointments/web/contract/AppointmentDefaultResponse.java
+++ b/omod/src/main/java/org/openmrs/module/appointments/web/contract/AppointmentDefaultResponse.java
@@ -28,6 +28,7 @@ public class AppointmentDefaultResponse {
 	private HashMap extensions;
 	private String teleconsultationLink;
 	private String priority;
+    private String[] fulfillingEncounters = new String[0];
 
 	public String getUuid() {
 		return uuid;
@@ -202,5 +203,13 @@ public class AppointmentDefaultResponse {
 
 	public void setDateAppointmentScheduled(Date dateAppointmentScheduled) {
 		this.dateAppointmentScheduled = dateAppointmentScheduled;
+	}
+
+	public String[] getFulfillingEncounters() {
+		return fulfillingEncounters;
+	}
+
+	public void setFulfillingEncounters(String[] fulfillingEncounters) {
+		this.fulfillingEncounters = fulfillingEncounters;
 	}
 }

--- a/omod/src/main/java/org/openmrs/module/appointments/web/contract/AppointmentRequest.java
+++ b/omod/src/main/java/org/openmrs/module/appointments/web/contract/AppointmentRequest.java
@@ -24,6 +24,7 @@ public class AppointmentRequest {
     private String comments;
     private List<AppointmentProviderDetail> providers = new ArrayList<>();
     private String priority;
+    private String[] fulfillingEncounters = new String[0];
 
     public String getAppointmentNumber() {
         return appointmentNumber;
@@ -144,4 +145,12 @@ public class AppointmentRequest {
     public void setDateAppointmentScheduled(Date dateAppointmentScheduled) {
         this.dateAppointmentScheduled = dateAppointmentScheduled;
     }
+
+    public String[] getFulfillingEncounters() {
+		return fulfillingEncounters;
+	}
+
+	public void setFulfillingEncounters(String[] fulfillingEncounters) {
+		this.fulfillingEncounters = fulfillingEncounters;
+	}
 }


### PR DESCRIPTION
## Description
This logic adds the ability to get and set fulfilling encounters for a specified appointment

## Screenshot
<img width="872" alt="Screenshot 2025-02-17 at 16 52 39" src="https://github.com/user-attachments/assets/4c85ab7d-6a14-4d5e-a58c-812a9e6134c6" />

## Ticket 
https://bahmni.atlassian.net/browse/BAH-3847