### PR TITLE
BAH-4557 Fix SonarCloud coverage not reflecting on main branch

### DIFF
--- a/.github/workflows/validate_pr.yml
+++ b/.github/workflows/validate_pr.yml
@@ -4,6 +4,8 @@
 name: Java CI with Maven
 
 on:
+  push:
+    branches: [ master ]
   pull_request:
     branches: [ master ]
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -6,7 +6,7 @@ sonar.sources=api/src/main/java,atom-feed/src/main/java,omod/src/main/java
 sonar.tests=api/src/test/java,atom-feed/src/test/java,omod/src/test/java
 sonar.java.binaries=api/target/classes,atom-feed/target/classes,omod/target/classes
 
-sonar.coverage.jacoco.xmlReportPaths=api/target/site/jacoco/jacoco.xml,atom-feed/target/site/jacoco/jacoco.xml,omod/target/site/jacoco/jacoco.xml
+sonar.coverage.jacoco.xmlReportPaths=api/target/jacoco-reports/jacoco.xml,atom-feed/target/jacoco-reports/jacoco.xml,omod/target/jacoco-reports/jacoco.xml
 
 sonar.coverage.exclusions=**/*Test.java,**/*IT.java
 


### PR DESCRIPTION

  1. Correct JaCoCo XML report paths in sonar-project.properties to match the configured outputDirectory (jacoco-reports) instead of the default/jacoco path
 2. Add push-to-master trigger to validate_pr.yml so SonarCloud performs a main branch analysis on merge.