### PR TITLE
Add appointment unavailability conflict - checks unavailability at dateAndTime, location, service and provider level

### DIFF
--- a/api/src/main/java/org/openmrs/module/appointments/conflicts/impl/AppointmentServiceUnavailabilityConflict.java
+++ b/api/src/main/java/org/openmrs/module/appointments/conflicts/impl/AppointmentServiceUnavailabilityConflict.java
@@ -1,19 +1,19 @@
 package org.openmrs.module.appointments.conflicts.impl;
 
 import org.openmrs.module.appointments.conflicts.AppointmentConflict;
-import org.openmrs.module.appointments.model.AppointmentConflictType;
 import org.openmrs.module.appointments.model.Appointment;
+import org.openmrs.module.appointments.model.AppointmentConflictType;
 import org.openmrs.module.appointments.model.AppointmentServiceDefinition;
 import org.openmrs.module.appointments.model.ServiceWeeklyAvailability;
 import org.openmrs.module.appointments.util.DateUtil;
 
 import java.sql.Time;
 import java.text.SimpleDateFormat;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -22,7 +22,7 @@ import static org.openmrs.module.appointments.util.DateUtil.getEpochTime;
 
 public class AppointmentServiceUnavailabilityConflict implements AppointmentConflict {
 
-    private final static String DAY_OF_WEEK_PATTERN = "EEEE";
+    private static final String DAY_OF_WEEK_PATTERN = "EEEE";
     private final SimpleDateFormat DayFormat = new SimpleDateFormat(DAY_OF_WEEK_PATTERN);
 
     @Override
@@ -32,7 +32,7 @@ public class AppointmentServiceUnavailabilityConflict implements AppointmentConf
 
     @Override
     public List<Appointment> getConflicts(List<Appointment> appointments) {
-        List<Appointment> conflictingAppointments = new ArrayList<>();
+     List<Appointment> conflictingAppointments = new ArrayList<>();
         for (Appointment appointment : appointments) {
             AppointmentServiceDefinition appointmentServiceDefinition = appointment.getService();
             boolean isConflicting = checkConflicts(appointment, appointmentServiceDefinition);
@@ -42,36 +42,42 @@ public class AppointmentServiceUnavailabilityConflict implements AppointmentConf
         return conflictingAppointments;
     }
 
-    private boolean checkConflicts(Appointment appointment, AppointmentServiceDefinition appointmentServiceDefinition) {
-        Set<ServiceWeeklyAvailability> weeklyAvailableDays = appointmentServiceDefinition.getWeeklyAvailability();
+    private boolean checkConflicts(Appointment appointment, AppointmentServiceDefinition service) {
+        ZoneId zone = DateUtil.getLocationZone(appointment.getLocation()).orElse(null);
+        Set<ServiceWeeklyAvailability> weeklyAvailableDays = service.getWeeklyAvailability();
         if (isObjectPresent(weeklyAvailableDays)) {
-            String appointmentDay = DayFormat.format(appointment.getStartDateTime());
+            String appointmentDay = zone != null
+                    ? appointment.getStartDateTime().toInstant().atZone(zone).getDayOfWeek().toString()
+                    : DayFormat.format(appointment.getStartDateTime());
             List<ServiceWeeklyAvailability> dayAvailabilities = weeklyAvailableDays.stream()
                     .filter(day -> day.isSameDay(appointmentDay)).collect(Collectors.toList());
             if (!dayAvailabilities.isEmpty())
                 return dayAvailabilities.stream().allMatch(availableDay ->
-                        checkTimeAvailability(appointment, availableDay.getStartTime().getTime(), availableDay.getEndTime().getTime()));
+                        checkTimeAvailability(appointment, availableDay.getStartTime().getTime(), availableDay.getEndTime().getTime(), zone));
             return true;
         }
-        Time serviceStartTime = appointmentServiceDefinition.getStartTime();
-        Time serviceEndTime = appointmentServiceDefinition.getEndTime();
+        Time serviceStartTime = service.getStartTime();
+        Time serviceEndTime = service.getEndTime();
         long serviceStartMillis = serviceStartTime != null ? serviceStartTime.getTime() : DateUtil.getStartOfDay().getTime();
         long serviceEndMillis = serviceEndTime != null ? serviceEndTime.getTime() : DateUtil.getEndOfDay().getTime();
-        return checkTimeAvailability(appointment, serviceStartMillis, serviceEndMillis);
+        return checkTimeAvailability(appointment, serviceStartMillis, serviceEndMillis, zone);
     }
 
     private boolean isObjectPresent(Collection<?> object) {
         return Objects.nonNull(object) && !object.isEmpty();
     }
 
-    private boolean checkTimeAvailability(Appointment appointment, long serviceStartTime, long serviceEndTime) {
-        long appointmentStartTimeMilliSeconds = getEpochTime(appointment.getStartDateTime().getTime());
-        long appointmentEndTimeMilliSeconds = getEpochTime(appointment.getEndDateTime().getTime());
-        long serviceStartTimeMilliSeconds = getEpochTime(serviceStartTime);
-        long serviceEndTimeMilliSeconds = getEpochTime(serviceEndTime);
-        boolean isConflict = (appointmentStartTimeMilliSeconds >= appointmentEndTimeMilliSeconds)
-                || ((appointmentStartTimeMilliSeconds < serviceStartTimeMilliSeconds)
-                || (appointmentEndTimeMilliSeconds > serviceEndTimeMilliSeconds));
-        return isConflict;
+    private boolean checkTimeAvailability(Appointment appointment, long serviceStartTime, long serviceEndTime, ZoneId zone) {
+        long appointmentStartMs = zone != null
+                ? getEpochTime(appointment.getStartDateTime().getTime(), zone)
+                : getEpochTime(appointment.getStartDateTime().getTime());
+        long appointmentEndMs = zone != null
+                ? getEpochTime(appointment.getEndDateTime().getTime(), zone)
+                : getEpochTime(appointment.getEndDateTime().getTime());
+        long serviceStartMs = getEpochTime(serviceStartTime);
+        long serviceEndMs = getEpochTime(serviceEndTime);
+        return (appointmentStartMs >= appointmentEndMs)
+                || (appointmentStartMs < serviceStartMs)
+                || (appointmentEndMs > serviceEndMs);
     }
 }

--- a/api/src/main/java/org/openmrs/module/appointments/conflicts/impl/AppointmentUnavailabilityConflict.java
+++ b/api/src/main/java/org/openmrs/module/appointments/conflicts/impl/AppointmentUnavailabilityConflict.java
@@ -1,0 +1,86 @@
+package org.openmrs.module.appointments.conflicts.impl;
+
+import org.openmrs.Provider;
+import org.openmrs.module.appointments.conflicts.AppointmentConflict;
+import org.openmrs.module.appointments.model.Appointment;
+import org.openmrs.module.appointments.model.AppointmentConflictType;
+import org.openmrs.module.appointments.model.AppointmentProvider;
+import org.openmrs.module.appointments.model.AppointmentUnavailability;
+import org.openmrs.module.appointments.search.param.AppointmentUnavailabilitySearchParams;
+import org.openmrs.module.appointments.service.AppointmentUnavailabilityService;
+import org.openmrs.module.appointments.util.DateUtil;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.openmrs.module.appointments.model.AppointmentConflictType.UNAVAILABILITY;
+
+public class AppointmentUnavailabilityConflict implements AppointmentConflict {
+
+    private AppointmentUnavailabilityService appointmentUnavailabilityService;
+
+    public void setAppointmentUnavailabilityService(AppointmentUnavailabilityService appointmentUnavailabilityService) {
+        this.appointmentUnavailabilityService = appointmentUnavailabilityService;
+    }
+
+    @Override
+    public AppointmentConflictType getType() {
+        return UNAVAILABILITY;
+    }
+
+    @Override
+    public List<Appointment> getConflicts(List<Appointment> appointments) {
+        return appointments.stream()
+                .filter(this::hasConflict)
+                .collect(Collectors.toList());
+    }
+
+    private boolean hasConflict(Appointment appointment) {
+        ZoneId zone = DateUtil.getLocationZone(appointment.getLocation()).orElse(ZoneId.systemDefault());
+        ZonedDateTime apptStart = appointment.getStartDateTime().toInstant().atZone(zone);
+        ZonedDateTime apptEnd = appointment.getEndDateTime().toInstant().atZone(zone);
+        List<AppointmentUnavailability> unavailabilities = getUnavailabilitiesForAppointment(apptStart, apptEnd);
+        return unavailabilities.stream().anyMatch(unavailability -> isConflict(appointment, unavailability, apptStart, apptEnd));
+    }
+
+    private List<AppointmentUnavailability> getUnavailabilitiesForAppointment(ZonedDateTime apptStart, ZonedDateTime apptEnd) {
+        AppointmentUnavailabilitySearchParams params = new AppointmentUnavailabilitySearchParams();
+        params.setStartDate(apptStart.toLocalDate().toString());
+        params.setEndDate(apptEnd.toLocalDate().toString());
+        return appointmentUnavailabilityService.getAll(params);
+    }
+
+    private boolean isConflict(Appointment appointment, AppointmentUnavailability unavailability, ZonedDateTime apptStart, ZonedDateTime apptEnd) {
+        if (!overlaps(apptStart, apptEnd, unavailability)) return false;
+        if (unavailability.getLocation() != null && !Objects.equals(unavailability.getLocation(), appointment.getLocation())) return false;
+        if (unavailability.getService() != null && !Objects.equals(unavailability.getService(), appointment.getService())) return false;
+        if (unavailability.getProvider() != null && !hasMatchingProvider(appointment, unavailability.getProvider())) return false;
+        return true;
+    }
+
+    private boolean overlaps(ZonedDateTime apptStart, ZonedDateTime apptEnd, AppointmentUnavailability unavailability) {
+        LocalDate apptDate = apptStart.toLocalDate();
+        LocalTime apptStartTime = apptStart.toLocalTime();
+        LocalTime apptEndTime = apptEnd.toLocalTime();
+
+        LocalDate unavailStartDate = unavailability.getStartDate().toLocalDate();
+        LocalDate unavailEndDate = unavailability.getEndDate().toLocalDate();
+        LocalTime unavailStartTime = unavailability.getStartTime().toLocalTime();
+        LocalTime unavailEndTime = unavailability.getEndTime().toLocalTime();
+
+        boolean dateInRange = !apptDate.isBefore(unavailStartDate) && !apptDate.isAfter(unavailEndDate);
+        boolean timeOverlaps = apptStartTime.isBefore(unavailEndTime) && apptEndTime.isAfter(unavailStartTime);
+
+        return dateInRange && timeOverlaps;
+    }
+
+    private boolean hasMatchingProvider(Appointment appointment, Provider provider) {
+        Set<AppointmentProvider> providers = appointment.getProviders();
+        return providers != null && providers.stream().anyMatch(ap -> provider.equals(ap.getProvider()));
+    }
+}

--- a/api/src/main/java/org/openmrs/module/appointments/model/AppointmentConflictType.java
+++ b/api/src/main/java/org/openmrs/module/appointments/model/AppointmentConflictType.java
@@ -1,5 +1,5 @@
 package org.openmrs.module.appointments.model;
 
 public enum AppointmentConflictType {
-    SERVICE_UNAVAILABLE, PATIENT_DOUBLE_BOOKING
+    SERVICE_UNAVAILABLE, PATIENT_DOUBLE_BOOKING, UNAVAILABILITY
 }

--- a/api/src/main/java/org/openmrs/module/appointments/service/impl/AppointmentUnavailabilityServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/appointments/service/impl/AppointmentUnavailabilityServiceImpl.java
@@ -12,6 +12,8 @@ import org.openmrs.module.appointments.model.AppointmentUnavailability;
 import org.openmrs.module.appointments.search.param.AppointmentUnavailabilitySearchParams;
 import org.openmrs.module.appointments.service.AppointmentServiceDefinitionService;
 import org.openmrs.module.appointments.service.AppointmentUnavailabilityService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.sql.Time;
@@ -29,12 +31,13 @@ public class AppointmentUnavailabilityServiceImpl implements AppointmentUnavaila
     private Log log = LogFactory.getLog(this.getClass());
 
     private final AppointmentUnavailabilityDao appointmentUnavailabilityDao;
-    private final AppointmentServiceDefinitionService appointmentServiceDefinitionService;
 
-    public AppointmentUnavailabilityServiceImpl(AppointmentUnavailabilityDao appointmentUnavailabilityDao,
-                                                 AppointmentServiceDefinitionService appointmentServiceDefinitionService) {
+    @Autowired
+    @Lazy
+    private AppointmentServiceDefinitionService appointmentServiceDefinitionService;
+
+    public AppointmentUnavailabilityServiceImpl(AppointmentUnavailabilityDao appointmentUnavailabilityDao) {
         this.appointmentUnavailabilityDao = appointmentUnavailabilityDao;
-        this.appointmentServiceDefinitionService = appointmentServiceDefinitionService;
     }
 
     @Override

--- a/api/src/main/java/org/openmrs/module/appointments/util/DateUtil.java
+++ b/api/src/main/java/org/openmrs/module/appointments/util/DateUtil.java
@@ -1,15 +1,22 @@
 package org.openmrs.module.appointments.util;
 
 import org.apache.commons.lang3.StringUtils;
+import org.openmrs.Location;
 
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.time.DateTimeException;
+import java.time.ZoneId;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.TimeZone;
 
 public class DateUtil {
+
+    private static final String TIMEZONE_ATTRIBUTE = "timeZone";
 
     public enum DateFormatType {
         UTC("yyyy-MM-dd'T'HH:mm:ss.SSS");
@@ -74,6 +81,26 @@ public class DateUtil {
         int seconds = calendar.get(Calendar.SECOND);
         long milliSeconds = ((hours * 3600 + minutes * 60 + seconds) * 1000);
         return milliSeconds;
+    }
+
+    public static long getEpochTime(long date, ZoneId zone) {
+        java.time.ZonedDateTime zdt = new Date(date).toInstant().atZone(zone);
+        return (zdt.getHour() * 3600L + zdt.getMinute() * 60L + zdt.getSecond()) * 1000L;
+    }
+
+    public static Optional<ZoneId> getLocationZone(Location location) {
+        if (location == null) return Optional.empty();
+        return location.getActiveAttributes().stream()
+                .filter(attr -> TIMEZONE_ATTRIBUTE.equalsIgnoreCase(attr.getAttributeType().getName()))
+                .map(attr -> {
+                    try {
+                        return ZoneId.of(String.valueOf(attr.getValue()));
+                    } catch (DateTimeException e) {
+                        return null;
+                    }
+                })
+                .filter(Objects::nonNull)
+                .findFirst();
     }
 
     public static Date getEndOfDay() {

--- a/api/src/main/resources/moduleApplicationContext.xml
+++ b/api/src/main/resources/moduleApplicationContext.xml
@@ -96,6 +96,10 @@
         <property name="appointmentDao" ref="appointmentDao"/>
     </bean>
 
+    <bean id="appointmentUnavailabilityConflict" class="org.openmrs.module.appointments.conflicts.impl.AppointmentUnavailabilityConflict">
+        <property name="appointmentUnavailabilityService" ref="appointmentUnavailabilityService"/>
+    </bean>
+
     <bean id="teleconsultationAppointmentServiceImpl" class="org.openmrs.module.appointments.service.impl.TeleconsultationAppointmentService">
         <property name="patientService">
             <ref bean="patientService"/>
@@ -165,6 +169,7 @@
                     <list>
                         <bean class="org.openmrs.module.appointments.conflicts.impl.AppointmentServiceUnavailabilityConflict"/>
                         <ref bean="patientDoubleBookingConflict"/>
+                        <ref bean="appointmentUnavailabilityConflict"/>
                     </list>
                 </property>
                 <property name="teleconsultationAppointmentService">
@@ -361,7 +366,6 @@
         <property name="target">
             <bean class="org.openmrs.module.appointments.service.impl.AppointmentUnavailabilityServiceImpl">
                 <constructor-arg ref="appointmentUnavailabilityDao"/>
-                <constructor-arg ref="appointmentServiceService"/>
             </bean>
         </property>
         <property name="preInterceptors">

--- a/api/src/test/java/org/openmrs/module/appointments/conflicts/impl/AppointmentServiceUnavailabilityConflictTest.java
+++ b/api/src/test/java/org/openmrs/module/appointments/conflicts/impl/AppointmentServiceUnavailabilityConflictTest.java
@@ -4,12 +4,16 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.runners.MockitoJUnitRunner;
+import org.openmrs.Location;
+import org.openmrs.LocationAttribute;
+import org.openmrs.LocationAttributeType;
 import org.openmrs.module.appointments.model.Appointment;
 import org.openmrs.module.appointments.model.AppointmentServiceDefinition;
 import org.openmrs.module.appointments.model.ServiceWeeklyAvailability;
 
 import java.sql.Time;
 import java.time.DayOfWeek;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -19,6 +23,8 @@ import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static org.openmrs.module.appointments.helper.DateHelper.getDate;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -27,11 +33,23 @@ public class AppointmentServiceUnavailabilityConflictTest {
     @InjectMocks
     private AppointmentServiceUnavailabilityConflict appointmentServiceUnavailabilityConflict;
 
+    private Location createLocationWithSystemTimezone() {
+        LocationAttributeType timezoneAttrType = mock(LocationAttributeType.class);
+        when(timezoneAttrType.getName()).thenReturn("timeZone");
+        LocationAttribute timezoneAttr = mock(LocationAttribute.class);
+        when(timezoneAttr.getAttributeType()).thenReturn(timezoneAttrType);
+        when(timezoneAttr.getValue()).thenReturn(ZoneId.systemDefault().getId());
+        Location location = mock(Location.class);
+        when(location.getActiveAttributes()).thenReturn(Collections.singletonList(timezoneAttr));
+        return location;
+    }
+
     @Test
     public void shouldReturnServiceUnavailableDayConflicts() {
         AppointmentServiceDefinition appointmentServiceDefinition = new AppointmentServiceDefinition();
         Appointment appointment = new Appointment();
         appointment.setService(appointmentServiceDefinition);
+        appointment.setLocation(createLocationWithSystemTimezone());
         appointment.setStartDateTime(getDate(2019, 8, 24, 11, 0, 0));
         appointment.setEndDateTime(getDate(2019, 8, 24, 12, 0, 0));
         appointment.setAppointmentId(1);
@@ -51,6 +69,7 @@ public class AppointmentServiceUnavailabilityConflictTest {
         AppointmentServiceDefinition appointmentServiceDefinition = new AppointmentServiceDefinition();
         Appointment appointment = new Appointment();
         appointment.setService(appointmentServiceDefinition);
+        appointment.setLocation(createLocationWithSystemTimezone());
         //Tuesday Appointment
         appointment.setStartDateTime(getDate(2019, 8, 24, 11, 30, 0));
         appointment.setEndDateTime(getDate(2019, 8, 24, 12, 0, 0));
@@ -75,19 +94,23 @@ public class AppointmentServiceUnavailabilityConflictTest {
     @Test
     public void shouldReturnServiceUnavailableTimeSlotConflict() {
         AppointmentServiceDefinition appointmentServiceDefinition = new AppointmentServiceDefinition();
+        Location location = createLocationWithSystemTimezone();
         //All Appointments are on Tuesday
         Appointment appointmentOne = new Appointment();
         appointmentOne.setService(appointmentServiceDefinition);
+        appointmentOne.setLocation(location);
         appointmentOne.setStartDateTime(getDate(2019, 8, 23, 6, 30, 0));
         appointmentOne.setEndDateTime(getDate(2019, 8, 23, 7, 0, 0));
         appointmentOne.setAppointmentId(2);
         Appointment appointmentTwo = new Appointment();
         appointmentTwo.setService(appointmentServiceDefinition);
+        appointmentTwo.setLocation(location);
         appointmentTwo.setStartDateTime(getDate(2019, 8, 23, 17, 30, 0));
         appointmentTwo.setEndDateTime(getDate(2019, 8, 23, 17, 0, 0));
         appointmentTwo.setAppointmentId(3);
         Appointment appointmentThree = new Appointment();
         appointmentThree.setService(appointmentServiceDefinition);
+        appointmentThree.setLocation(location);
         appointmentThree.setStartDateTime(getDate(2019, 8, 23, 16, 30, 0));
         appointmentThree.setEndDateTime(getDate(2019, 8, 23, 17, 1, 0));
         appointmentThree.setAppointmentId(4);
@@ -102,7 +125,7 @@ public class AppointmentServiceUnavailabilityConflictTest {
         Set<ServiceWeeklyAvailability> availabilities = new HashSet<>(Arrays.asList(day1, day2));
         appointmentServiceDefinition.setWeeklyAvailability(availabilities);
 
-        List<Appointment> conflictingAppointments= new ArrayList<>();
+        List<Appointment> conflictingAppointments = new ArrayList<>();
         conflictingAppointments.addAll(appointmentServiceUnavailabilityConflict.getConflicts(Arrays.asList(appointmentOne, appointmentTwo, appointmentThree)));
 
         assertNotNull(conflictingAppointments);
@@ -115,19 +138,23 @@ public class AppointmentServiceUnavailabilityConflictTest {
     @Test
     public void shouldNotReturnServiceUnavailableConflictsForMoreSlotsInSingleDay() {
         AppointmentServiceDefinition appointmentServiceDefinition = new AppointmentServiceDefinition();
+        Location location = createLocationWithSystemTimezone();
         // All Appointments are on Monday
         Appointment appointmentOne = new Appointment();
         appointmentOne.setService(appointmentServiceDefinition);
+        appointmentOne.setLocation(location);
         appointmentOne.setStartDateTime(getDate(2019, 8, 23, 6, 30, 0));
         appointmentOne.setEndDateTime(getDate(2019, 8, 23, 7, 0, 0));
         appointmentOne.setAppointmentId(2);
         Appointment appointmentTwo = new Appointment();
         appointmentTwo.setService(appointmentServiceDefinition);
+        appointmentTwo.setLocation(location);
         appointmentTwo.setStartDateTime(getDate(2019, 8, 23, 16, 30, 0));
         appointmentTwo.setEndDateTime(getDate(2019, 8, 23, 17, 30, 0));
         appointmentTwo.setAppointmentId(3);
         Appointment appointmentThree = new Appointment();
         appointmentThree.setService(appointmentServiceDefinition);
+        appointmentThree.setLocation(location);
         appointmentThree.setStartDateTime(getDate(2019, 8, 23, 16, 30, 0));
         appointmentThree.setEndDateTime(getDate(2019, 8, 23, 17, 0, 0));
         appointmentThree.setAppointmentId(4);
@@ -152,18 +179,22 @@ public class AppointmentServiceUnavailabilityConflictTest {
     @Test
     public void shouldNotReturnServiceUnavailableConflictsForServicesWithNoAvailabilityInformation() {
         AppointmentServiceDefinition appointmentServiceDefinition = new AppointmentServiceDefinition();
+        Location location = createLocationWithSystemTimezone();
         Appointment appointmentOne = new Appointment();
         appointmentOne.setService(appointmentServiceDefinition);
+        appointmentOne.setLocation(location);
         appointmentOne.setStartDateTime(getDate(2019, 8, 23, 6, 30, 0));
         appointmentOne.setEndDateTime(getDate(2019, 8, 23, 7, 0, 0));
         appointmentOne.setAppointmentId(2);
         Appointment appointmentTwo = new Appointment();
         appointmentTwo.setService(appointmentServiceDefinition);
+        appointmentTwo.setLocation(location);
         appointmentTwo.setStartDateTime(getDate(2019, 8, 23, 16, 30, 0));
         appointmentTwo.setEndDateTime(getDate(2019, 8, 23, 17, 30, 0));
         appointmentTwo.setAppointmentId(3);
         Appointment appointmentThree = new Appointment();
         appointmentThree.setService(appointmentServiceDefinition);
+        appointmentThree.setLocation(location);
         appointmentThree.setStartDateTime(getDate(2019, 8, 23, 16, 30, 0));
         appointmentThree.setEndDateTime(getDate(2019, 8, 23, 17, 0, 0));
         appointmentThree.setAppointmentId(4);
@@ -184,6 +215,7 @@ public class AppointmentServiceUnavailabilityConflictTest {
         appointment.setStartDateTime(getDate(2019, 8, 23, 11, 30, 0));
         appointment.setEndDateTime(getDate(2019, 8, 23, 11, 0, 0));
         appointment.setService(appointmentServiceDefinition);
+        appointment.setLocation(createLocationWithSystemTimezone());
         appointment.setAppointmentId(1);
         ServiceWeeklyAvailability day1 = new ServiceWeeklyAvailability();
         day1.setStartTime(new Time(8, 30, 0));
@@ -208,6 +240,7 @@ public class AppointmentServiceUnavailabilityConflictTest {
         appointment.setStartDateTime(getDate(2019, 8, 23, 11, 0, 0));
         appointment.setEndDateTime(getDate(2019, 8, 23, 11, 30, 0));
         appointment.setService(appointmentServiceDefinition);
+        appointment.setLocation(createLocationWithSystemTimezone());
         appointment.setAppointmentId(1);
         appointmentServiceDefinition.setStartTime(new Time(11, 30, 0));
         appointmentServiceDefinition.setEndTime(new Time(17, 0, 0));
@@ -216,5 +249,26 @@ public class AppointmentServiceUnavailabilityConflictTest {
 
         assertNotNull(appointments);
         assertEquals(appointment, appointments.get(0));
+    }
+
+    @Test
+    public void shouldUseSystemTimezoneWhenLocationHasNoTimezoneAttribute() {
+        Location location = mock(Location.class);
+        when(location.getActiveAttributes()).thenReturn(Collections.emptyList());
+
+        AppointmentServiceDefinition service = new AppointmentServiceDefinition();
+        service.setStartTime(new Time(8, 30, 0));
+        service.setEndTime(new Time(17, 0, 0));
+
+        Appointment appointment = new Appointment();
+        appointment.setService(service);
+        appointment.setLocation(location);
+        appointment.setStartDateTime(getDate(2019, 8, 24, 11, 30, 0));
+        appointment.setEndDateTime(getDate(2019, 8, 24, 12, 0, 0));
+
+        List<Appointment> conflicts = appointmentServiceUnavailabilityConflict.getConflicts(Collections.singletonList(appointment));
+
+        assertNotNull(conflicts);
+        assertEquals(0, conflicts.size());
     }
 }

--- a/api/src/test/java/org/openmrs/module/appointments/conflicts/impl/AppointmentUnavailabilityConflictTest.java
+++ b/api/src/test/java/org/openmrs/module/appointments/conflicts/impl/AppointmentUnavailabilityConflictTest.java
@@ -1,0 +1,163 @@
+package org.openmrs.module.appointments.conflicts.impl;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.openmrs.Location;
+import org.openmrs.Provider;
+import org.openmrs.module.appointments.model.Appointment;
+import org.openmrs.module.appointments.model.AppointmentProvider;
+import org.openmrs.module.appointments.model.AppointmentServiceDefinition;
+import org.openmrs.module.appointments.model.AppointmentUnavailability;
+import org.openmrs.module.appointments.search.param.AppointmentUnavailabilitySearchParams;
+import org.openmrs.module.appointments.service.AppointmentUnavailabilityService;
+
+import java.sql.Date;
+import java.sql.Time;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.openmrs.module.appointments.helper.DateHelper.getDate;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AppointmentUnavailabilityConflictTest {
+
+    @InjectMocks
+    private AppointmentUnavailabilityConflict appointmentUnavailabilityConflict;
+
+    @Mock
+    private AppointmentUnavailabilityService appointmentUnavailabilityService;
+
+    private AppointmentUnavailability buildUnavailability(String startDate, String startTime, String endDate, String endTime) {
+        AppointmentUnavailability unavailability = new AppointmentUnavailability();
+        unavailability.setStartDate(Date.valueOf(startDate));
+        unavailability.setStartTime(Time.valueOf(startTime));
+        unavailability.setEndDate(Date.valueOf(endDate));
+        unavailability.setEndTime(Time.valueOf(endTime));
+        return unavailability;
+    }
+
+    private Appointment buildAppointment() {
+        Appointment appointment = new Appointment();
+        appointment.setStartDateTime(getDate(2026, 5, 28, 19, 0, 0));
+        appointment.setEndDateTime(getDate(2026, 5, 28, 20, 0, 0));
+        return appointment;
+    }
+
+    @Test
+    public void shouldReturnConflictWhenAppointmentOverlapsUnavailability() {
+        AppointmentUnavailability unavailability = buildUnavailability("2026-06-28", "18:00:00", "2026-06-28", "21:00:00");
+        when(appointmentUnavailabilityService.getAll(any(AppointmentUnavailabilitySearchParams.class)))
+                .thenReturn(Collections.singletonList(unavailability));
+
+        Appointment appointment = buildAppointment();
+        List<Appointment> conflicts = appointmentUnavailabilityConflict.getConflicts(Collections.singletonList(appointment));
+
+        assertNotNull(conflicts);
+        assertEquals(1, conflicts.size());
+        assertEquals(appointment, conflicts.get(0));
+    }
+
+    @Test
+    public void shouldNotReturnConflictWhenAppointmentIsOutsideUnavailabilityTime() {
+        AppointmentUnavailability unavailability = buildUnavailability("2026-06-28", "10:00:00", "2026-06-28", "11:00:00");
+        when(appointmentUnavailabilityService.getAll(any(AppointmentUnavailabilitySearchParams.class)))
+                .thenReturn(Collections.singletonList(unavailability));
+
+        Appointment appointment = buildAppointment();
+        List<Appointment> conflicts = appointmentUnavailabilityConflict.getConflicts(Collections.singletonList(appointment));
+
+        assertNotNull(conflicts);
+        assertEquals(0, conflicts.size());
+    }
+
+    @Test
+    public void shouldNotReturnConflictWhenLocationDoesNotMatch() {
+        Location appointmentLocation = mock(Location.class);
+        Location unavailabilityLocation = mock(Location.class);
+
+        AppointmentUnavailability unavailability = buildUnavailability("2026-06-28", "18:00:00", "2026-06-28", "21:00:00");
+        unavailability.setLocation(unavailabilityLocation);
+        when(appointmentUnavailabilityService.getAll(any(AppointmentUnavailabilitySearchParams.class)))
+                .thenReturn(Collections.singletonList(unavailability));
+
+        Appointment appointment = buildAppointment();
+        appointment.setLocation(appointmentLocation);
+
+        List<Appointment> conflicts = appointmentUnavailabilityConflict.getConflicts(Collections.singletonList(appointment));
+
+        assertNotNull(conflicts);
+        assertEquals(0, conflicts.size());
+    }
+
+    @Test
+    public void shouldNotReturnConflictWhenServiceDoesNotMatch() {
+        AppointmentServiceDefinition appointmentService = new AppointmentServiceDefinition();
+        AppointmentServiceDefinition unavailabilityService = new AppointmentServiceDefinition();
+
+        AppointmentUnavailability unavailability = buildUnavailability("2026-06-28", "18:00:00", "2026-06-28", "21:00:00");
+        unavailability.setService(unavailabilityService);
+        when(appointmentUnavailabilityService.getAll(any(AppointmentUnavailabilitySearchParams.class)))
+                .thenReturn(Collections.singletonList(unavailability));
+
+        Appointment appointment = buildAppointment();
+        appointment.setService(appointmentService);
+
+        List<Appointment> conflicts = appointmentUnavailabilityConflict.getConflicts(Collections.singletonList(appointment));
+
+        assertNotNull(conflicts);
+        assertEquals(0, conflicts.size());
+    }
+
+    @Test
+    public void shouldNotReturnConflictWhenProviderDoesNotMatch() {
+        Provider appointmentProvider = mock(Provider.class);
+        Provider unavailabilityProvider = mock(Provider.class);
+
+        AppointmentProvider apptProvider = new AppointmentProvider();
+        apptProvider.setProvider(appointmentProvider);
+
+        AppointmentUnavailability unavailability = buildUnavailability("2026-06-28", "18:00:00", "2026-06-28", "21:00:00");
+        unavailability.setProvider(unavailabilityProvider);
+        when(appointmentUnavailabilityService.getAll(any(AppointmentUnavailabilitySearchParams.class)))
+                .thenReturn(Collections.singletonList(unavailability));
+
+        Appointment appointment = buildAppointment();
+        appointment.setProviders(new HashSet<>(Collections.singletonList(apptProvider)));
+
+        List<Appointment> conflicts = appointmentUnavailabilityConflict.getConflicts(Collections.singletonList(appointment));
+
+        assertNotNull(conflicts);
+        assertEquals(0, conflicts.size());
+    }
+
+    @Test
+    public void shouldReturnConflictWhenProviderIsNullAndLocationServiceAndTimeMatch() {
+        Location location = mock(Location.class);
+        AppointmentServiceDefinition service = new AppointmentServiceDefinition();
+
+        AppointmentUnavailability unavailability = buildUnavailability("2026-06-28", "18:00:00", "2026-06-28", "21:00:00");
+        unavailability.setLocation(location);
+        unavailability.setService(service);
+        when(appointmentUnavailabilityService.getAll(any(AppointmentUnavailabilitySearchParams.class)))
+                .thenReturn(Collections.singletonList(unavailability));
+
+        Appointment appointment = buildAppointment();
+        appointment.setLocation(location);
+        appointment.setService(service);
+
+        List<Appointment> conflicts = appointmentUnavailabilityConflict.getConflicts(Collections.singletonList(appointment));
+
+        assertNotNull(conflicts);
+        assertEquals(1, conflicts.size());
+        assertEquals(appointment, conflicts.get(0));
+    }
+}

--- a/api/src/test/java/org/openmrs/module/appointments/service/impl/AppointmentUnavailabilityServiceImplTest.java
+++ b/api/src/test/java/org/openmrs/module/appointments/service/impl/AppointmentUnavailabilityServiceImplTest.java
@@ -7,6 +7,7 @@ import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.openmrs.Location;
 import org.openmrs.Provider;
 import org.openmrs.User;
@@ -67,7 +68,8 @@ public class AppointmentUnavailabilityServiceImplTest {
     @Before
     public void setUp() throws Exception {
         MockitoAnnotations.initMocks(this);
-        service = new AppointmentUnavailabilityServiceImpl(appointmentUnavailabilityDao, appointmentServiceDefinitionService);
+        service = new AppointmentUnavailabilityServiceImpl(appointmentUnavailabilityDao);
+        ReflectionTestUtils.setField(service, "appointmentServiceDefinitionService", appointmentServiceDefinitionService);
         mockStatic(Context.class);
         authenticatedUser = new User(1);
         PowerMockito.when(Context.getAuthenticatedUser()).thenReturn(authenticatedUser);

--- a/api/src/test/java/org/openmrs/module/appointments/util/DateUtilTest.java
+++ b/api/src/test/java/org/openmrs/module/appointments/util/DateUtilTest.java
@@ -1,20 +1,29 @@
 package org.openmrs.module.appointments.util;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static org.openmrs.module.appointments.util.DateUtil.convertToLocalDateFromUTC;
 import static org.openmrs.module.appointments.util.DateUtil.getEpochTime;
 
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.time.ZoneId;
 import java.util.Calendar;
+import java.util.Collections;
 import java.util.Date;
 import java.util.Locale;
+import java.util.Optional;
 import java.util.TimeZone;
 
 import org.junit.Test;
+import org.openmrs.Location;
+import org.openmrs.LocationAttribute;
+import org.openmrs.LocationAttributeType;
 
 public class DateUtilTest {
     @Test
@@ -162,6 +171,61 @@ public class DateUtilTest {
         String result = DateUtil.convertUTCToGivenFormat(dateTime, format, timeZone);
 
         assertNull(result);
+    }
+
+    @Test
+    public void shouldConvertDateToMilliSecondsForGivenTimezone() {
+        // 11:00 AM UTC = 19:00 (7PM) in Asia/Manila (UTC+8) = 68400000 ms since midnight
+        long utcMs = 11 * 3600 * 1000L;
+        long result = getEpochTime(utcMs, ZoneId.of("Asia/Manila"));
+        assertEquals(68400000L, result);
+    }
+
+    @Test
+    public void shouldReturnEmptyWhenLocationIsNull() {
+        Optional<ZoneId> zone = DateUtil.getLocationZone(null);
+        assertFalse(zone.isPresent());
+    }
+
+    @Test
+    public void shouldReturnZoneIdWhenLocationHasValidTimezoneAttribute() {
+        LocationAttributeType attrType = mock(LocationAttributeType.class);
+        when(attrType.getName()).thenReturn("timeZone");
+        LocationAttribute attr = mock(LocationAttribute.class);
+        when(attr.getAttributeType()).thenReturn(attrType);
+        when(attr.getValue()).thenReturn("Asia/Manila");
+        Location location = mock(Location.class);
+        when(location.getActiveAttributes()).thenReturn(Collections.singletonList(attr));
+
+        Optional<ZoneId> zone = DateUtil.getLocationZone(location);
+
+        assertTrue(zone.isPresent());
+        assertEquals(ZoneId.of("Asia/Manila"), zone.get());
+    }
+
+    @Test
+    public void shouldReturnEmptyWhenLocationHasNoTimezoneAttribute() {
+        Location location = mock(Location.class);
+        when(location.getActiveAttributes()).thenReturn(Collections.emptyList());
+
+        Optional<ZoneId> zone = DateUtil.getLocationZone(location);
+
+        assertFalse(zone.isPresent());
+    }
+
+    @Test
+    public void shouldReturnEmptyWhenTimezoneAttributeValueIsInvalid() {
+        LocationAttributeType attrType = mock(LocationAttributeType.class);
+        when(attrType.getName()).thenReturn("timeZone");
+        LocationAttribute attr = mock(LocationAttribute.class);
+        when(attr.getAttributeType()).thenReturn(attrType);
+        when(attr.getValue()).thenReturn("InvalidZone");
+        Location location = mock(Location.class);
+        when(location.getActiveAttributes()).thenReturn(Collections.singletonList(attr));
+
+        Optional<ZoneId> zone = DateUtil.getLocationZone(location);
+
+        assertFalse(zone.isPresent());
     }
 
 }

--- a/api/src/test/resources/TestingApplicationContext.xml
+++ b/api/src/test/resources/TestingApplicationContext.xml
@@ -138,6 +138,8 @@
         <property name="appointmentDao" ref="appointmentDao"/>
     </bean>
 
+    <bean id="appointmentUnavailabilityConflict" class="org.openmrs.module.appointments.conflicts.impl.AppointmentServiceUnavailabilityConflict"/>
+
     <bean id="appointmentsService" class="org.springframework.transaction.interceptor.TransactionProxyFactoryBean">
         <property name="transactionManager">
             <ref bean="transactionManager"/>

--- a/omod/src/test/resources/TestingApplicationContext.xml
+++ b/omod/src/test/resources/TestingApplicationContext.xml
@@ -68,6 +68,8 @@
 		<property name="appointmentDao" ref="appointmentDao"/>
 	</bean>
 
+	<bean id="appointmentUnavailabilityConflict" class="org.openmrs.module.appointments.conflicts.impl.AppointmentServiceUnavailabilityConflict"/>
+
 	<bean id="appointmentNumberGenerator" class="org.openmrs.module.appointments.service.impl.DefaultAppointmentNumberGeneratorImpl"/>
 
 	<bean id="defaultRecurringAppointmentNumberGenerator"
@@ -214,7 +216,6 @@
         <property name="target">
             <bean class="org.openmrs.module.appointments.service.impl.AppointmentUnavailabilityServiceImpl">
                 <constructor-arg ref="appointmentUnavailabilityDao"/>
-                <constructor-arg ref="appointmentServiceService"/>
             </bean>
         </property>
         <property name="preInterceptors">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for detecting appointment unavailability conflicts.
  * Appointment conflict checks now respect a location’s time zone when available.

* **Bug Fixes**
  * Improved time-based conflict matching so appointments are compared using the correct local day and time.
  * Added fallback behavior when no location time zone is configured.
  * Ensured unavailability rules can match by location, service, and provider as expected.

* **Tests**
  * Added and updated tests covering time zone handling and unavailability conflict scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->