### PR TITLE
BAH-4840: Add date/time, location, service, and provider conflict checks for ap…

### DIFF
--- a/api/src/main/java/org/openmrs/module/appointments/conflicts/impl/AppointmentServiceUnavailabilityConflict.java
+++ b/api/src/main/java/org/openmrs/module/appointments/conflicts/impl/AppointmentServiceUnavailabilityConflict.java
@@ -17,6 +17,7 @@ import java.sql.Time;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.ZoneId;
+import java.util.Optional;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Objects;
@@ -48,7 +49,10 @@ public class AppointmentServiceUnavailabilityConflict implements AppointmentConf
 
     private ZoneId getTimezoneForAppointment(Appointment appointment) {
         if (appointment.getLocation() != null) {
-            return LocationUtil.getLocationZone(appointment.getLocation()).orElse(ZoneId.systemDefault());
+            Optional<ZoneId> locationZone = LocationUtil.getLocationZone(appointment.getLocation());
+            if (locationZone.isPresent()) {
+                return locationZone.get();
+            }
         }
         AppointmentServiceDefinition service = appointment.getService();
         if (service != null) {

--- a/api/src/main/java/org/openmrs/module/appointments/conflicts/impl/AppointmentServiceUnavailabilityConflict.java
+++ b/api/src/main/java/org/openmrs/module/appointments/conflicts/impl/AppointmentServiceUnavailabilityConflict.java
@@ -14,8 +14,6 @@ import org.openmrs.module.appointments.util.DateUtil;
 import org.openmrs.module.appointments.util.LocationUtil;
 
 import java.sql.Time;
-import java.time.LocalDate;
-import java.time.LocalTime;
 import java.time.ZoneId;
 import java.util.Optional;
 import java.time.ZonedDateTime;
@@ -117,19 +115,17 @@ public class AppointmentServiceUnavailabilityConflict implements AppointmentConf
     }
 
     private boolean isDateTimeOverlap(ZonedDateTime apptStart, ZonedDateTime apptEnd, AppointmentUnavailability unavailability) {
-        LocalDate apptDate = apptStart.toLocalDate();
-        LocalTime apptStartTime = apptStart.toLocalTime();
-        LocalTime apptEndTime = apptEnd.toLocalTime();
+        ZoneId zone = apptStart.getZone();
+        ZonedDateTime unavailStart = ZonedDateTime.of(
+                unavailability.getStartDate().toLocalDate(),
+                unavailability.getStartTime().toLocalTime(),
+                zone);
+        ZonedDateTime unavailEnd = ZonedDateTime.of(
+                unavailability.getEndDate().toLocalDate(),
+                unavailability.getEndTime().toLocalTime(),
+                zone);
 
-        LocalDate unavailStartDate = unavailability.getStartDate().toLocalDate();
-        LocalDate unavailEndDate = unavailability.getEndDate().toLocalDate();
-        LocalTime unavailStartTime = unavailability.getStartTime().toLocalTime();
-        LocalTime unavailEndTime = unavailability.getEndTime().toLocalTime();
-
-        boolean dateInRange = !apptDate.isBefore(unavailStartDate) && !apptDate.isAfter(unavailEndDate);
-        boolean timeOverlaps = apptStartTime.isBefore(unavailEndTime) && apptEndTime.isAfter(unavailStartTime);
-
-        return dateInRange && timeOverlaps;
+        return apptStart.isBefore(unavailEnd) && apptEnd.isAfter(unavailStart);
     }
 
     private boolean hasMatchingProvider(Appointment appointment, Provider provider) {

--- a/api/src/main/java/org/openmrs/module/appointments/conflicts/impl/AppointmentServiceUnavailabilityConflict.java
+++ b/api/src/main/java/org/openmrs/module/appointments/conflicts/impl/AppointmentServiceUnavailabilityConflict.java
@@ -1,19 +1,25 @@
 package org.openmrs.module.appointments.conflicts.impl;
 
+import org.openmrs.Provider;
 import org.openmrs.module.appointments.conflicts.AppointmentConflict;
-import org.openmrs.module.appointments.model.AppointmentConflictType;
 import org.openmrs.module.appointments.model.Appointment;
+import org.openmrs.module.appointments.model.AppointmentConflictType;
+import org.openmrs.module.appointments.model.AppointmentProvider;
 import org.openmrs.module.appointments.model.AppointmentServiceDefinition;
+import org.openmrs.module.appointments.model.AppointmentUnavailability;
 import org.openmrs.module.appointments.model.ServiceWeeklyAvailability;
+import org.openmrs.module.appointments.dao.AppointmentUnavailabilityDao;
+import org.openmrs.module.appointments.search.param.AppointmentUnavailabilitySearchParams;
 import org.openmrs.module.appointments.util.DateUtil;
+import org.openmrs.module.appointments.util.LocationUtil;
 
 import java.sql.Time;
-import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Collection;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -22,8 +28,11 @@ import static org.openmrs.module.appointments.util.DateUtil.getEpochTime;
 
 public class AppointmentServiceUnavailabilityConflict implements AppointmentConflict {
 
-    private final static String DAY_OF_WEEK_PATTERN = "EEEE";
-    private final SimpleDateFormat DayFormat = new SimpleDateFormat(DAY_OF_WEEK_PATTERN);
+    private AppointmentUnavailabilityDao appointmentUnavailabilityDao;
+
+    public void setAppointmentUnavailabilityDao(AppointmentUnavailabilityDao appointmentUnavailabilityDao) {
+        this.appointmentUnavailabilityDao = appointmentUnavailabilityDao;
+    }
 
     @Override
     public AppointmentConflictType getType() {
@@ -32,46 +41,95 @@ public class AppointmentServiceUnavailabilityConflict implements AppointmentConf
 
     @Override
     public List<Appointment> getConflicts(List<Appointment> appointments) {
-        List<Appointment> conflictingAppointments = new ArrayList<>();
-        for (Appointment appointment : appointments) {
-            AppointmentServiceDefinition appointmentServiceDefinition = appointment.getService();
-            boolean isConflicting = checkConflicts(appointment, appointmentServiceDefinition);
-            if (isConflicting)
-                conflictingAppointments.add(appointment);
-        }
-        return conflictingAppointments;
+        return appointments.stream()
+                .filter(appointment -> isOutsideServiceHours(appointment) || hasUnavailabilityConflict(appointment))
+                .collect(Collectors.toList());
     }
 
-    private boolean checkConflicts(Appointment appointment, AppointmentServiceDefinition appointmentServiceDefinition) {
-        Set<ServiceWeeklyAvailability> weeklyAvailableDays = appointmentServiceDefinition.getWeeklyAvailability();
-        if (isObjectPresent(weeklyAvailableDays)) {
-            String appointmentDay = DayFormat.format(appointment.getStartDateTime());
+    private ZoneId getTimezoneForAppointment(Appointment appointment) {
+        if (appointment.getLocation() != null) {
+            return LocationUtil.getLocationZone(appointment.getLocation()).orElse(ZoneId.systemDefault());
+        }
+        AppointmentServiceDefinition service = appointment.getService();
+        if (service != null) {
+            return LocationUtil.getLocationZone(service.getLocation()).orElse(ZoneId.systemDefault());
+        }
+        return ZoneId.systemDefault();
+    }
+
+    private boolean isOutsideServiceHours(Appointment appointment) {
+        AppointmentServiceDefinition service = appointment.getService();
+        if (service == null) return false;
+        ZoneId zone = getTimezoneForAppointment(appointment);
+        Set<ServiceWeeklyAvailability> weeklyAvailableDays = service.getWeeklyAvailability();
+        if (weeklyAvailableDays != null && !weeklyAvailableDays.isEmpty()) {
+            String appointmentDay = appointment.getStartDateTime().toInstant().atZone(zone).getDayOfWeek().toString();
             List<ServiceWeeklyAvailability> dayAvailabilities = weeklyAvailableDays.stream()
                     .filter(day -> day.isSameDay(appointmentDay)).collect(Collectors.toList());
             if (!dayAvailabilities.isEmpty())
                 return dayAvailabilities.stream().allMatch(availableDay ->
-                        checkTimeAvailability(appointment, availableDay.getStartTime().getTime(), availableDay.getEndTime().getTime()));
+                        hasTimeConflict(appointment, availableDay.getStartTime().getTime(), availableDay.getEndTime().getTime(), zone));
             return true;
         }
-        Time serviceStartTime = appointmentServiceDefinition.getStartTime();
-        Time serviceEndTime = appointmentServiceDefinition.getEndTime();
+        Time serviceStartTime = service.getStartTime();
+        Time serviceEndTime = service.getEndTime();
         long serviceStartMillis = serviceStartTime != null ? serviceStartTime.getTime() : DateUtil.getStartOfDay().getTime();
         long serviceEndMillis = serviceEndTime != null ? serviceEndTime.getTime() : DateUtil.getEndOfDay().getTime();
-        return checkTimeAvailability(appointment, serviceStartMillis, serviceEndMillis);
+        return hasTimeConflict(appointment, serviceStartMillis, serviceEndMillis, zone);
     }
 
-    private boolean isObjectPresent(Collection<?> object) {
-        return Objects.nonNull(object) && !object.isEmpty();
+    private boolean hasTimeConflict(Appointment appointment, long serviceStartTime, long serviceEndTime, ZoneId zone) {
+        long appointmentStartMs = getEpochTime(appointment.getStartDateTime().getTime(), zone);
+        long appointmentEndMs = getEpochTime(appointment.getEndDateTime().getTime(), zone);
+        long serviceStartMs = getEpochTime(serviceStartTime);
+        long serviceEndMs = getEpochTime(serviceEndTime);
+        return (appointmentStartMs >= appointmentEndMs)
+                || (appointmentStartMs < serviceStartMs)
+                || (appointmentEndMs > serviceEndMs);
     }
 
-    private boolean checkTimeAvailability(Appointment appointment, long serviceStartTime, long serviceEndTime) {
-        long appointmentStartTimeMilliSeconds = getEpochTime(appointment.getStartDateTime().getTime());
-        long appointmentEndTimeMilliSeconds = getEpochTime(appointment.getEndDateTime().getTime());
-        long serviceStartTimeMilliSeconds = getEpochTime(serviceStartTime);
-        long serviceEndTimeMilliSeconds = getEpochTime(serviceEndTime);
-        boolean isConflict = (appointmentStartTimeMilliSeconds >= appointmentEndTimeMilliSeconds)
-                || ((appointmentStartTimeMilliSeconds < serviceStartTimeMilliSeconds)
-                || (appointmentEndTimeMilliSeconds > serviceEndTimeMilliSeconds));
-        return isConflict;
+    private boolean hasUnavailabilityConflict(Appointment appointment) {
+        if (appointmentUnavailabilityDao == null) return false;
+        ZoneId zone = getTimezoneForAppointment(appointment);
+        ZonedDateTime apptStart = appointment.getStartDateTime().toInstant().atZone(zone);
+        ZonedDateTime apptEnd = appointment.getEndDateTime().toInstant().atZone(zone);
+        List<AppointmentUnavailability> unavailabilities = fetchUnavailabilities(apptStart, apptEnd);
+        return unavailabilities.stream().anyMatch(unavailability -> conflictsWithUnavailability(appointment, unavailability, apptStart, apptEnd));
+    }
+
+    private List<AppointmentUnavailability> fetchUnavailabilities(ZonedDateTime apptStart, ZonedDateTime apptEnd) {
+        AppointmentUnavailabilitySearchParams params = new AppointmentUnavailabilitySearchParams();
+        params.setStartDate(apptStart.toLocalDate().toString());
+        params.setEndDate(apptEnd.toLocalDate().toString());
+        return appointmentUnavailabilityDao.getAll(params);
+    }
+
+    private boolean conflictsWithUnavailability(Appointment appointment, AppointmentUnavailability unavailability, ZonedDateTime apptStart, ZonedDateTime apptEnd) {
+        if (!isDateTimeOverlap(apptStart, apptEnd, unavailability)) return false;
+        if (unavailability.getLocation() != null && !Objects.equals(unavailability.getLocation(), appointment.getLocation())) return false;
+        if (unavailability.getService() != null && !Objects.equals(unavailability.getService(), appointment.getService())) return false;
+        if (unavailability.getProvider() != null && !hasMatchingProvider(appointment, unavailability.getProvider())) return false;
+        return true;
+    }
+
+    private boolean isDateTimeOverlap(ZonedDateTime apptStart, ZonedDateTime apptEnd, AppointmentUnavailability unavailability) {
+        LocalDate apptDate = apptStart.toLocalDate();
+        LocalTime apptStartTime = apptStart.toLocalTime();
+        LocalTime apptEndTime = apptEnd.toLocalTime();
+
+        LocalDate unavailStartDate = unavailability.getStartDate().toLocalDate();
+        LocalDate unavailEndDate = unavailability.getEndDate().toLocalDate();
+        LocalTime unavailStartTime = unavailability.getStartTime().toLocalTime();
+        LocalTime unavailEndTime = unavailability.getEndTime().toLocalTime();
+
+        boolean dateInRange = !apptDate.isBefore(unavailStartDate) && !apptDate.isAfter(unavailEndDate);
+        boolean timeOverlaps = apptStartTime.isBefore(unavailEndTime) && apptEndTime.isAfter(unavailStartTime);
+
+        return dateInRange && timeOverlaps;
+    }
+
+    private boolean hasMatchingProvider(Appointment appointment, Provider provider) {
+        Set<AppointmentProvider> providers = appointment.getProviders();
+        return providers != null && providers.stream().anyMatch(ap -> provider.equals(ap.getProvider()));
     }
 }

--- a/api/src/main/java/org/openmrs/module/appointments/util/DateUtil.java
+++ b/api/src/main/java/org/openmrs/module/appointments/util/DateUtil.java
@@ -5,6 +5,7 @@ import org.apache.commons.lang3.StringUtils;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.time.ZoneId;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.TimeZone;
@@ -74,6 +75,11 @@ public class DateUtil {
         int seconds = calendar.get(Calendar.SECOND);
         long milliSeconds = ((hours * 3600 + minutes * 60 + seconds) * 1000);
         return milliSeconds;
+    }
+
+     public static long getEpochTime(long date, ZoneId zone) {
+        java.time.ZonedDateTime zdt = new Date(date).toInstant().atZone(zone);
+        return (zdt.getHour() * 3600L + zdt.getMinute() * 60L + zdt.getSecond()) * 1000L;
     }
 
     public static Date getEndOfDay() {

--- a/api/src/main/java/org/openmrs/module/appointments/util/LocationUtil.java
+++ b/api/src/main/java/org/openmrs/module/appointments/util/LocationUtil.java
@@ -1,0 +1,34 @@
+package org.openmrs.module.appointments.util;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.openmrs.Location;
+
+import java.time.DateTimeException;
+import java.time.ZoneId;
+import java.util.Optional;
+
+public class LocationUtil {
+
+    private static final Log log = LogFactory.getLog(LocationUtil.class);
+    private static final String TIMEZONE_ATTRIBUTE = "timeZone";
+
+    public static Optional<ZoneId> getLocationZone(Location location) {
+        if (location == null) return Optional.empty();
+        return location.getActiveAttributes().stream()
+                .filter(attr -> TIMEZONE_ATTRIBUTE.equalsIgnoreCase(attr.getAttributeType().getName()))
+                .map(attr -> {
+                    String zoneId = String.valueOf(attr.getValue());
+                    try {
+                        return Optional.of(ZoneId.of(zoneId));
+                    } catch (DateTimeException e) {
+                        log.error("Invalid timezone '" + zoneId
+                                + "' configured for location '" + location.getName() + "'", e);
+                        return Optional.<ZoneId>empty();
+                    }
+                })
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .findFirst();
+    }
+}

--- a/api/src/main/resources/moduleApplicationContext.xml
+++ b/api/src/main/resources/moduleApplicationContext.xml
@@ -163,7 +163,9 @@
                 </property>
                 <property name="appointmentConflicts">
                     <list>
-                        <bean class="org.openmrs.module.appointments.conflicts.impl.AppointmentServiceUnavailabilityConflict"/>
+                        <bean class="org.openmrs.module.appointments.conflicts.impl.AppointmentServiceUnavailabilityConflict">
+                            <property name="appointmentUnavailabilityDao" ref="appointmentUnavailabilityDao"/>
+                        </bean>
                         <ref bean="patientDoubleBookingConflict"/>
                     </list>
                 </property>

--- a/api/src/test/java/org/openmrs/module/appointments/conflicts/impl/AppointmentServiceUnavailabilityConflictTest.java
+++ b/api/src/test/java/org/openmrs/module/appointments/conflicts/impl/AppointmentServiceUnavailabilityConflictTest.java
@@ -414,4 +414,21 @@ public class AppointmentServiceUnavailabilityConflictTest {
         assertEquals(1, conflicts.size());
         assertEquals(appointment, conflicts.get(0));
     }
+
+    @Test
+    public void shouldReturnConflictWhenAppointmentFallsWithinOvernightUnavailability() {
+        AppointmentUnavailability unavailability = buildUnavailability("2026-06-28", "18:00:00", "2026-06-29", "09:00:00");
+        when(appointmentUnavailabilityDao.getAll(any(AppointmentUnavailabilitySearchParams.class)))
+                .thenReturn(Collections.singletonList(unavailability));
+
+        Appointment appointment = new Appointment();
+        appointment.setStartDateTime(getDate(2026, 5, 29, 8, 0, 0));
+        appointment.setEndDateTime(getDate(2026, 5, 29, 8, 30, 0));
+
+        List<Appointment> conflicts = appointmentServiceUnavailabilityConflict.getConflicts(Collections.singletonList(appointment));
+
+        assertNotNull(conflicts);
+        assertEquals(1, conflicts.size());
+        assertEquals(appointment, conflicts.get(0));
+    }
 }

--- a/api/src/test/java/org/openmrs/module/appointments/conflicts/impl/AppointmentServiceUnavailabilityConflictTest.java
+++ b/api/src/test/java/org/openmrs/module/appointments/conflicts/impl/AppointmentServiceUnavailabilityConflictTest.java
@@ -1,15 +1,27 @@
 package org.openmrs.module.appointments.conflicts.impl;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
+import org.openmrs.Location;
+import org.openmrs.LocationAttribute;
+import org.openmrs.LocationAttributeType;
+import org.openmrs.Provider;
 import org.openmrs.module.appointments.model.Appointment;
+import org.openmrs.module.appointments.model.AppointmentProvider;
 import org.openmrs.module.appointments.model.AppointmentServiceDefinition;
+import org.openmrs.module.appointments.model.AppointmentUnavailability;
 import org.openmrs.module.appointments.model.ServiceWeeklyAvailability;
+import org.openmrs.module.appointments.dao.AppointmentUnavailabilityDao;
+import org.openmrs.module.appointments.search.param.AppointmentUnavailabilitySearchParams;
 
+import java.sql.Date;
 import java.sql.Time;
 import java.time.DayOfWeek;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -19,6 +31,9 @@ import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static org.openmrs.module.appointments.helper.DateHelper.getDate;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -27,11 +42,48 @@ public class AppointmentServiceUnavailabilityConflictTest {
     @InjectMocks
     private AppointmentServiceUnavailabilityConflict appointmentServiceUnavailabilityConflict;
 
+    @Mock
+    private AppointmentUnavailabilityDao appointmentUnavailabilityDao;
+
+    @Before
+    public void setUp() {
+        when(appointmentUnavailabilityDao.getAll(any(AppointmentUnavailabilitySearchParams.class)))
+                .thenReturn(Collections.emptyList());
+    }
+
+    private Location createLocationWithSystemTimezone() {
+        LocationAttributeType timezoneAttrType = mock(LocationAttributeType.class);
+        when(timezoneAttrType.getName()).thenReturn("timeZone");
+        LocationAttribute timezoneAttr = mock(LocationAttribute.class);
+        when(timezoneAttr.getAttributeType()).thenReturn(timezoneAttrType);
+        when(timezoneAttr.getValue()).thenReturn(ZoneId.systemDefault().getId());
+        Location location = mock(Location.class);
+        when(location.getActiveAttributes()).thenReturn(Collections.singletonList(timezoneAttr));
+        return location;
+    }
+
+    private AppointmentUnavailability buildUnavailability(String startDate, String startTime, String endDate, String endTime) {
+        AppointmentUnavailability unavailability = new AppointmentUnavailability();
+        unavailability.setStartDate(Date.valueOf(startDate));
+        unavailability.setStartTime(Time.valueOf(startTime));
+        unavailability.setEndDate(Date.valueOf(endDate));
+        unavailability.setEndTime(Time.valueOf(endTime));
+        return unavailability;
+    }
+
+    private Appointment buildAppointment() {
+        Appointment appointment = new Appointment();
+        appointment.setStartDateTime(getDate(2026, 5, 28, 19, 0, 0));
+        appointment.setEndDateTime(getDate(2026, 5, 28, 20, 0, 0));
+        return appointment;
+    }
+
     @Test
     public void shouldReturnServiceUnavailableDayConflicts() {
         AppointmentServiceDefinition appointmentServiceDefinition = new AppointmentServiceDefinition();
         Appointment appointment = new Appointment();
         appointment.setService(appointmentServiceDefinition);
+        appointment.setLocation(createLocationWithSystemTimezone());
         appointment.setStartDateTime(getDate(2019, 8, 24, 11, 0, 0));
         appointment.setEndDateTime(getDate(2019, 8, 24, 12, 0, 0));
         appointment.setAppointmentId(1);
@@ -51,17 +103,18 @@ public class AppointmentServiceUnavailabilityConflictTest {
         AppointmentServiceDefinition appointmentServiceDefinition = new AppointmentServiceDefinition();
         Appointment appointment = new Appointment();
         appointment.setService(appointmentServiceDefinition);
+        appointment.setLocation(createLocationWithSystemTimezone());
         //Tuesday Appointment
         appointment.setStartDateTime(getDate(2019, 8, 24, 11, 30, 0));
         appointment.setEndDateTime(getDate(2019, 8, 24, 12, 0, 0));
         appointment.setAppointmentId(2);
         ServiceWeeklyAvailability day1 = new ServiceWeeklyAvailability();
-        day1.setStartTime(new Time(8, 30, 0));
-        day1.setEndTime(new Time(17, 30, 0));
+        day1.setStartTime(Time.valueOf("08:30:00"));
+        day1.setEndTime(Time.valueOf("17:30:00"));
         day1.setDayOfWeek(DayOfWeek.MONDAY);
         ServiceWeeklyAvailability day2 = new ServiceWeeklyAvailability();
-        day2.setStartTime(new Time(8, 30, 0));
-        day2.setEndTime(new Time(17, 30, 0));
+        day2.setStartTime(Time.valueOf("08:30:00"));
+        day2.setEndTime(Time.valueOf("17:30:00"));
         day2.setDayOfWeek(DayOfWeek.TUESDAY);
         Set<ServiceWeeklyAvailability> availabilities = new HashSet<>(Arrays.asList(day1, day2));
         appointmentServiceDefinition.setWeeklyAvailability(availabilities);
@@ -75,34 +128,38 @@ public class AppointmentServiceUnavailabilityConflictTest {
     @Test
     public void shouldReturnServiceUnavailableTimeSlotConflict() {
         AppointmentServiceDefinition appointmentServiceDefinition = new AppointmentServiceDefinition();
+        Location location = createLocationWithSystemTimezone();
         //All Appointments are on Tuesday
         Appointment appointmentOne = new Appointment();
         appointmentOne.setService(appointmentServiceDefinition);
+        appointmentOne.setLocation(location);
         appointmentOne.setStartDateTime(getDate(2019, 8, 23, 6, 30, 0));
         appointmentOne.setEndDateTime(getDate(2019, 8, 23, 7, 0, 0));
         appointmentOne.setAppointmentId(2);
         Appointment appointmentTwo = new Appointment();
         appointmentTwo.setService(appointmentServiceDefinition);
+        appointmentTwo.setLocation(location);
         appointmentTwo.setStartDateTime(getDate(2019, 8, 23, 17, 30, 0));
         appointmentTwo.setEndDateTime(getDate(2019, 8, 23, 17, 0, 0));
         appointmentTwo.setAppointmentId(3);
         Appointment appointmentThree = new Appointment();
         appointmentThree.setService(appointmentServiceDefinition);
+        appointmentThree.setLocation(location);
         appointmentThree.setStartDateTime(getDate(2019, 8, 23, 16, 30, 0));
         appointmentThree.setEndDateTime(getDate(2019, 8, 23, 17, 1, 0));
         appointmentThree.setAppointmentId(4);
         ServiceWeeklyAvailability day1 = new ServiceWeeklyAvailability();
-        day1.setStartTime(new Time(8, 30, 0));
-        day1.setEndTime(new Time(17, 0, 0));
+        day1.setStartTime(Time.valueOf("08:30:00"));
+        day1.setEndTime(Time.valueOf("17:00:00"));
         day1.setDayOfWeek(DayOfWeek.MONDAY);
         ServiceWeeklyAvailability day2 = new ServiceWeeklyAvailability();
-        day2.setStartTime(new Time(8, 30, 0));
-        day2.setEndTime(new Time(17, 0, 0));
+        day2.setStartTime(Time.valueOf("08:30:00"));
+        day2.setEndTime(Time.valueOf("17:00:00"));
         day2.setDayOfWeek(DayOfWeek.TUESDAY);
         Set<ServiceWeeklyAvailability> availabilities = new HashSet<>(Arrays.asList(day1, day2));
         appointmentServiceDefinition.setWeeklyAvailability(availabilities);
 
-        List<Appointment> conflictingAppointments= new ArrayList<>();
+        List<Appointment> conflictingAppointments = new ArrayList<>();
         conflictingAppointments.addAll(appointmentServiceUnavailabilityConflict.getConflicts(Arrays.asList(appointmentOne, appointmentTwo, appointmentThree)));
 
         assertNotNull(conflictingAppointments);
@@ -115,29 +172,33 @@ public class AppointmentServiceUnavailabilityConflictTest {
     @Test
     public void shouldNotReturnServiceUnavailableConflictsForMoreSlotsInSingleDay() {
         AppointmentServiceDefinition appointmentServiceDefinition = new AppointmentServiceDefinition();
+        Location location = createLocationWithSystemTimezone();
         // All Appointments are on Monday
         Appointment appointmentOne = new Appointment();
         appointmentOne.setService(appointmentServiceDefinition);
+        appointmentOne.setLocation(location);
         appointmentOne.setStartDateTime(getDate(2019, 8, 23, 6, 30, 0));
         appointmentOne.setEndDateTime(getDate(2019, 8, 23, 7, 0, 0));
         appointmentOne.setAppointmentId(2);
         Appointment appointmentTwo = new Appointment();
         appointmentTwo.setService(appointmentServiceDefinition);
+        appointmentTwo.setLocation(location);
         appointmentTwo.setStartDateTime(getDate(2019, 8, 23, 16, 30, 0));
         appointmentTwo.setEndDateTime(getDate(2019, 8, 23, 17, 30, 0));
         appointmentTwo.setAppointmentId(3);
         Appointment appointmentThree = new Appointment();
         appointmentThree.setService(appointmentServiceDefinition);
+        appointmentThree.setLocation(location);
         appointmentThree.setStartDateTime(getDate(2019, 8, 23, 16, 30, 0));
         appointmentThree.setEndDateTime(getDate(2019, 8, 23, 17, 0, 0));
         appointmentThree.setAppointmentId(4);
         ServiceWeeklyAvailability day1 = new ServiceWeeklyAvailability();
-        day1.setStartTime(new Time(6, 30, 0));
-        day1.setEndTime(new Time(14, 0, 0));
+        day1.setStartTime(Time.valueOf("06:30:00"));
+        day1.setEndTime(Time.valueOf("14:00:00"));
         day1.setDayOfWeek(DayOfWeek.MONDAY);
         ServiceWeeklyAvailability day2 = new ServiceWeeklyAvailability();
-        day2.setStartTime(new Time(16, 30, 0));
-        day2.setEndTime(new Time(19, 0, 0));
+        day2.setStartTime(Time.valueOf("16:30:00"));
+        day2.setEndTime(Time.valueOf("19:00:00"));
         day2.setDayOfWeek(DayOfWeek.MONDAY);
         Set<ServiceWeeklyAvailability> availabilities = new HashSet<>(Arrays.asList(day1, day2));
         appointmentServiceDefinition.setWeeklyAvailability(availabilities);
@@ -152,18 +213,22 @@ public class AppointmentServiceUnavailabilityConflictTest {
     @Test
     public void shouldNotReturnServiceUnavailableConflictsForServicesWithNoAvailabilityInformation() {
         AppointmentServiceDefinition appointmentServiceDefinition = new AppointmentServiceDefinition();
+        Location location = createLocationWithSystemTimezone();
         Appointment appointmentOne = new Appointment();
         appointmentOne.setService(appointmentServiceDefinition);
+        appointmentOne.setLocation(location);
         appointmentOne.setStartDateTime(getDate(2019, 8, 23, 6, 30, 0));
         appointmentOne.setEndDateTime(getDate(2019, 8, 23, 7, 0, 0));
         appointmentOne.setAppointmentId(2);
         Appointment appointmentTwo = new Appointment();
         appointmentTwo.setService(appointmentServiceDefinition);
+        appointmentTwo.setLocation(location);
         appointmentTwo.setStartDateTime(getDate(2019, 8, 23, 16, 30, 0));
         appointmentTwo.setEndDateTime(getDate(2019, 8, 23, 17, 30, 0));
         appointmentTwo.setAppointmentId(3);
         Appointment appointmentThree = new Appointment();
         appointmentThree.setService(appointmentServiceDefinition);
+        appointmentThree.setLocation(location);
         appointmentThree.setStartDateTime(getDate(2019, 8, 23, 16, 30, 0));
         appointmentThree.setEndDateTime(getDate(2019, 8, 23, 17, 0, 0));
         appointmentThree.setAppointmentId(4);
@@ -184,14 +249,15 @@ public class AppointmentServiceUnavailabilityConflictTest {
         appointment.setStartDateTime(getDate(2019, 8, 23, 11, 30, 0));
         appointment.setEndDateTime(getDate(2019, 8, 23, 11, 0, 0));
         appointment.setService(appointmentServiceDefinition);
+        appointment.setLocation(createLocationWithSystemTimezone());
         appointment.setAppointmentId(1);
         ServiceWeeklyAvailability day1 = new ServiceWeeklyAvailability();
-        day1.setStartTime(new Time(8, 30, 0));
-        day1.setEndTime(new Time(17, 0, 0));
+        day1.setStartTime(Time.valueOf("08:30:00"));
+        day1.setEndTime(Time.valueOf("17:00:00"));
         day1.setDayOfWeek(DayOfWeek.MONDAY);
         ServiceWeeklyAvailability day2 = new ServiceWeeklyAvailability();
-        day2.setStartTime(new Time(8, 30, 0));
-        day2.setEndTime(new Time(17, 0, 0));
+        day2.setStartTime(Time.valueOf("08:30:00"));
+        day2.setEndTime(Time.valueOf("17:00:00"));
         day2.setDayOfWeek(DayOfWeek.TUESDAY);
         Set<ServiceWeeklyAvailability> availabilities = new HashSet<>(Arrays.asList(day1, day2));
         appointmentServiceDefinition.setWeeklyAvailability(availabilities);
@@ -208,13 +274,144 @@ public class AppointmentServiceUnavailabilityConflictTest {
         appointment.setStartDateTime(getDate(2019, 8, 23, 11, 0, 0));
         appointment.setEndDateTime(getDate(2019, 8, 23, 11, 30, 0));
         appointment.setService(appointmentServiceDefinition);
+        appointment.setLocation(createLocationWithSystemTimezone());
         appointment.setAppointmentId(1);
-        appointmentServiceDefinition.setStartTime(new Time(11, 30, 0));
-        appointmentServiceDefinition.setEndTime(new Time(17, 0, 0));
+        appointmentServiceDefinition.setStartTime(Time.valueOf("11:30:00"));
+        appointmentServiceDefinition.setEndTime(Time.valueOf("17:00:00"));
 
         List<Appointment> appointments = appointmentServiceUnavailabilityConflict.getConflicts(Collections.singletonList(appointment));
 
         assertNotNull(appointments);
         assertEquals(appointment, appointments.get(0));
+    }
+
+    @Test
+    public void shouldUseSystemTimezoneWhenLocationHasNoTimezoneAttribute() {
+        Location location = mock(Location.class);
+        when(location.getActiveAttributes()).thenReturn(Collections.emptyList());
+
+        AppointmentServiceDefinition service = new AppointmentServiceDefinition();
+        service.setStartTime(Time.valueOf("08:30:00"));
+        service.setEndTime(Time.valueOf("17:00:00"));
+
+        Appointment appointment = new Appointment();
+        appointment.setService(service);
+        appointment.setLocation(location);
+        appointment.setStartDateTime(getDate(2019, 8, 24, 11, 30, 0));
+        appointment.setEndDateTime(getDate(2019, 8, 24, 12, 0, 0));
+
+        List<Appointment> conflicts = appointmentServiceUnavailabilityConflict.getConflicts(Collections.singletonList(appointment));
+
+        assertNotNull(conflicts);
+        assertEquals(0, conflicts.size());
+    }
+
+    @Test
+    public void shouldReturnConflictWhenAppointmentOverlapsUnavailability() {
+        AppointmentUnavailability unavailability = buildUnavailability("2026-06-28", "18:00:00", "2026-06-28", "21:00:00");
+        when(appointmentUnavailabilityDao.getAll(any(AppointmentUnavailabilitySearchParams.class)))
+                .thenReturn(Collections.singletonList(unavailability));
+
+        Appointment appointment = buildAppointment();
+        List<Appointment> conflicts = appointmentServiceUnavailabilityConflict.getConflicts(Collections.singletonList(appointment));
+
+        assertNotNull(conflicts);
+        assertEquals(1, conflicts.size());
+        assertEquals(appointment, conflicts.get(0));
+    }
+
+    @Test
+    public void shouldNotReturnConflictWhenAppointmentIsOutsideUnavailabilityTime() {
+        AppointmentUnavailability unavailability = buildUnavailability("2026-06-28", "10:00:00", "2026-06-28", "11:00:00");
+        when(appointmentUnavailabilityDao.getAll(any(AppointmentUnavailabilitySearchParams.class)))
+                .thenReturn(Collections.singletonList(unavailability));
+
+        Appointment appointment = buildAppointment();
+        List<Appointment> conflicts = appointmentServiceUnavailabilityConflict.getConflicts(Collections.singletonList(appointment));
+
+        assertNotNull(conflicts);
+        assertEquals(0, conflicts.size());
+    }
+
+    @Test
+    public void shouldNotReturnConflictWhenLocationDoesNotMatch() {
+        Location appointmentLocation = mock(Location.class);
+        Location unavailabilityLocation = mock(Location.class);
+
+        AppointmentUnavailability unavailability = buildUnavailability("2026-06-28", "18:00:00", "2026-06-28", "21:00:00");
+        unavailability.setLocation(unavailabilityLocation);
+        when(appointmentUnavailabilityDao.getAll(any(AppointmentUnavailabilitySearchParams.class)))
+                .thenReturn(Collections.singletonList(unavailability));
+
+        Appointment appointment = buildAppointment();
+        appointment.setLocation(appointmentLocation);
+
+        List<Appointment> conflicts = appointmentServiceUnavailabilityConflict.getConflicts(Collections.singletonList(appointment));
+
+        assertNotNull(conflicts);
+        assertEquals(0, conflicts.size());
+    }
+
+    @Test
+    public void shouldNotReturnConflictWhenServiceDoesNotMatch() {
+        AppointmentServiceDefinition appointmentService = new AppointmentServiceDefinition();
+        AppointmentServiceDefinition unavailabilityService = new AppointmentServiceDefinition();
+
+        AppointmentUnavailability unavailability = buildUnavailability("2026-06-28", "18:00:00", "2026-06-28", "21:00:00");
+        unavailability.setService(unavailabilityService);
+        when(appointmentUnavailabilityDao.getAll(any(AppointmentUnavailabilitySearchParams.class)))
+                .thenReturn(Collections.singletonList(unavailability));
+
+        Appointment appointment = buildAppointment();
+        appointment.setService(appointmentService);
+
+        List<Appointment> conflicts = appointmentServiceUnavailabilityConflict.getConflicts(Collections.singletonList(appointment));
+
+        assertNotNull(conflicts);
+        assertEquals(0, conflicts.size());
+    }
+
+    @Test
+    public void shouldNotReturnConflictWhenProviderDoesNotMatch() {
+        Provider appointmentProvider = mock(Provider.class);
+        Provider unavailabilityProvider = mock(Provider.class);
+
+        AppointmentProvider apptProvider = new AppointmentProvider();
+        apptProvider.setProvider(appointmentProvider);
+
+        AppointmentUnavailability unavailability = buildUnavailability("2026-06-28", "18:00:00", "2026-06-28", "21:00:00");
+        unavailability.setProvider(unavailabilityProvider);
+        when(appointmentUnavailabilityDao.getAll(any(AppointmentUnavailabilitySearchParams.class)))
+                .thenReturn(Collections.singletonList(unavailability));
+
+        Appointment appointment = buildAppointment();
+        appointment.setProviders(new HashSet<>(Collections.singletonList(apptProvider)));
+
+        List<Appointment> conflicts = appointmentServiceUnavailabilityConflict.getConflicts(Collections.singletonList(appointment));
+
+        assertNotNull(conflicts);
+        assertEquals(0, conflicts.size());
+    }
+
+    @Test
+    public void shouldReturnConflictWhenProviderIsNullAndLocationServiceAndTimeMatch() {
+        Location location = mock(Location.class);
+        AppointmentServiceDefinition service = new AppointmentServiceDefinition();
+
+        AppointmentUnavailability unavailability = buildUnavailability("2026-06-28", "18:00:00", "2026-06-28", "21:00:00");
+        unavailability.setLocation(location);
+        unavailability.setService(service);
+        when(appointmentUnavailabilityDao.getAll(any(AppointmentUnavailabilitySearchParams.class)))
+                .thenReturn(Collections.singletonList(unavailability));
+
+        Appointment appointment = buildAppointment();
+        appointment.setLocation(location);
+        appointment.setService(service);
+
+        List<Appointment> conflicts = appointmentServiceUnavailabilityConflict.getConflicts(Collections.singletonList(appointment));
+
+        assertNotNull(conflicts);
+        assertEquals(1, conflicts.size());
+        assertEquals(appointment, conflicts.get(0));
     }
 }

--- a/api/src/test/java/org/openmrs/module/appointments/conflicts/impl/AppointmentServiceUnavailabilityConflictTest.java
+++ b/api/src/test/java/org/openmrs/module/appointments/conflicts/impl/AppointmentServiceUnavailabilityConflictTest.java
@@ -7,8 +7,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.openmrs.Location;
-import org.openmrs.LocationAttribute;
-import org.openmrs.LocationAttributeType;
 import org.openmrs.Provider;
 import org.openmrs.module.appointments.model.Appointment;
 import org.openmrs.module.appointments.model.AppointmentProvider;
@@ -21,7 +19,6 @@ import org.openmrs.module.appointments.search.param.AppointmentUnavailabilitySea
 import java.sql.Date;
 import java.sql.Time;
 import java.time.DayOfWeek;
-import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -51,17 +48,6 @@ public class AppointmentServiceUnavailabilityConflictTest {
                 .thenReturn(Collections.emptyList());
     }
 
-    private Location createLocationWithSystemTimezone() {
-        LocationAttributeType timezoneAttrType = mock(LocationAttributeType.class);
-        when(timezoneAttrType.getName()).thenReturn("timeZone");
-        LocationAttribute timezoneAttr = mock(LocationAttribute.class);
-        when(timezoneAttr.getAttributeType()).thenReturn(timezoneAttrType);
-        when(timezoneAttr.getValue()).thenReturn(ZoneId.systemDefault().getId());
-        Location location = mock(Location.class);
-        when(location.getActiveAttributes()).thenReturn(Collections.singletonList(timezoneAttr));
-        return location;
-    }
-
     private AppointmentUnavailability buildUnavailability(String startDate, String startTime, String endDate, String endTime) {
         AppointmentUnavailability unavailability = new AppointmentUnavailability();
         unavailability.setStartDate(Date.valueOf(startDate));
@@ -83,7 +69,6 @@ public class AppointmentServiceUnavailabilityConflictTest {
         AppointmentServiceDefinition appointmentServiceDefinition = new AppointmentServiceDefinition();
         Appointment appointment = new Appointment();
         appointment.setService(appointmentServiceDefinition);
-        appointment.setLocation(createLocationWithSystemTimezone());
         appointment.setStartDateTime(getDate(2019, 8, 24, 11, 0, 0));
         appointment.setEndDateTime(getDate(2019, 8, 24, 12, 0, 0));
         appointment.setAppointmentId(1);
@@ -103,7 +88,6 @@ public class AppointmentServiceUnavailabilityConflictTest {
         AppointmentServiceDefinition appointmentServiceDefinition = new AppointmentServiceDefinition();
         Appointment appointment = new Appointment();
         appointment.setService(appointmentServiceDefinition);
-        appointment.setLocation(createLocationWithSystemTimezone());
         //Tuesday Appointment
         appointment.setStartDateTime(getDate(2019, 8, 24, 11, 30, 0));
         appointment.setEndDateTime(getDate(2019, 8, 24, 12, 0, 0));
@@ -128,23 +112,19 @@ public class AppointmentServiceUnavailabilityConflictTest {
     @Test
     public void shouldReturnServiceUnavailableTimeSlotConflict() {
         AppointmentServiceDefinition appointmentServiceDefinition = new AppointmentServiceDefinition();
-        Location location = createLocationWithSystemTimezone();
         //All Appointments are on Tuesday
         Appointment appointmentOne = new Appointment();
         appointmentOne.setService(appointmentServiceDefinition);
-        appointmentOne.setLocation(location);
         appointmentOne.setStartDateTime(getDate(2019, 8, 23, 6, 30, 0));
         appointmentOne.setEndDateTime(getDate(2019, 8, 23, 7, 0, 0));
         appointmentOne.setAppointmentId(2);
         Appointment appointmentTwo = new Appointment();
         appointmentTwo.setService(appointmentServiceDefinition);
-        appointmentTwo.setLocation(location);
         appointmentTwo.setStartDateTime(getDate(2019, 8, 23, 17, 30, 0));
         appointmentTwo.setEndDateTime(getDate(2019, 8, 23, 17, 0, 0));
         appointmentTwo.setAppointmentId(3);
         Appointment appointmentThree = new Appointment();
         appointmentThree.setService(appointmentServiceDefinition);
-        appointmentThree.setLocation(location);
         appointmentThree.setStartDateTime(getDate(2019, 8, 23, 16, 30, 0));
         appointmentThree.setEndDateTime(getDate(2019, 8, 23, 17, 1, 0));
         appointmentThree.setAppointmentId(4);
@@ -172,23 +152,19 @@ public class AppointmentServiceUnavailabilityConflictTest {
     @Test
     public void shouldNotReturnServiceUnavailableConflictsForMoreSlotsInSingleDay() {
         AppointmentServiceDefinition appointmentServiceDefinition = new AppointmentServiceDefinition();
-        Location location = createLocationWithSystemTimezone();
         // All Appointments are on Monday
         Appointment appointmentOne = new Appointment();
         appointmentOne.setService(appointmentServiceDefinition);
-        appointmentOne.setLocation(location);
         appointmentOne.setStartDateTime(getDate(2019, 8, 23, 6, 30, 0));
         appointmentOne.setEndDateTime(getDate(2019, 8, 23, 7, 0, 0));
         appointmentOne.setAppointmentId(2);
         Appointment appointmentTwo = new Appointment();
         appointmentTwo.setService(appointmentServiceDefinition);
-        appointmentTwo.setLocation(location);
         appointmentTwo.setStartDateTime(getDate(2019, 8, 23, 16, 30, 0));
         appointmentTwo.setEndDateTime(getDate(2019, 8, 23, 17, 30, 0));
         appointmentTwo.setAppointmentId(3);
         Appointment appointmentThree = new Appointment();
         appointmentThree.setService(appointmentServiceDefinition);
-        appointmentThree.setLocation(location);
         appointmentThree.setStartDateTime(getDate(2019, 8, 23, 16, 30, 0));
         appointmentThree.setEndDateTime(getDate(2019, 8, 23, 17, 0, 0));
         appointmentThree.setAppointmentId(4);
@@ -213,22 +189,18 @@ public class AppointmentServiceUnavailabilityConflictTest {
     @Test
     public void shouldNotReturnServiceUnavailableConflictsForServicesWithNoAvailabilityInformation() {
         AppointmentServiceDefinition appointmentServiceDefinition = new AppointmentServiceDefinition();
-        Location location = createLocationWithSystemTimezone();
         Appointment appointmentOne = new Appointment();
         appointmentOne.setService(appointmentServiceDefinition);
-        appointmentOne.setLocation(location);
         appointmentOne.setStartDateTime(getDate(2019, 8, 23, 6, 30, 0));
         appointmentOne.setEndDateTime(getDate(2019, 8, 23, 7, 0, 0));
         appointmentOne.setAppointmentId(2);
         Appointment appointmentTwo = new Appointment();
         appointmentTwo.setService(appointmentServiceDefinition);
-        appointmentTwo.setLocation(location);
         appointmentTwo.setStartDateTime(getDate(2019, 8, 23, 16, 30, 0));
         appointmentTwo.setEndDateTime(getDate(2019, 8, 23, 17, 30, 0));
         appointmentTwo.setAppointmentId(3);
         Appointment appointmentThree = new Appointment();
         appointmentThree.setService(appointmentServiceDefinition);
-        appointmentThree.setLocation(location);
         appointmentThree.setStartDateTime(getDate(2019, 8, 23, 16, 30, 0));
         appointmentThree.setEndDateTime(getDate(2019, 8, 23, 17, 0, 0));
         appointmentThree.setAppointmentId(4);
@@ -249,7 +221,6 @@ public class AppointmentServiceUnavailabilityConflictTest {
         appointment.setStartDateTime(getDate(2019, 8, 23, 11, 30, 0));
         appointment.setEndDateTime(getDate(2019, 8, 23, 11, 0, 0));
         appointment.setService(appointmentServiceDefinition);
-        appointment.setLocation(createLocationWithSystemTimezone());
         appointment.setAppointmentId(1);
         ServiceWeeklyAvailability day1 = new ServiceWeeklyAvailability();
         day1.setStartTime(Time.valueOf("08:30:00"));
@@ -274,7 +245,6 @@ public class AppointmentServiceUnavailabilityConflictTest {
         appointment.setStartDateTime(getDate(2019, 8, 23, 11, 0, 0));
         appointment.setEndDateTime(getDate(2019, 8, 23, 11, 30, 0));
         appointment.setService(appointmentServiceDefinition);
-        appointment.setLocation(createLocationWithSystemTimezone());
         appointment.setAppointmentId(1);
         appointmentServiceDefinition.setStartTime(Time.valueOf("11:30:00"));
         appointmentServiceDefinition.setEndTime(Time.valueOf("17:00:00"));

--- a/api/src/test/java/org/openmrs/module/appointments/util/DateUtilTest.java
+++ b/api/src/test/java/org/openmrs/module/appointments/util/DateUtilTest.java
@@ -9,6 +9,7 @@ import static org.openmrs.module.appointments.util.DateUtil.getEpochTime;
 
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.time.ZoneId;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.Locale;
@@ -89,6 +90,13 @@ public class DateUtilTest {
         String dateString = "2017-03-15T16:57:09.0Z";
         Date date = convertToLocalDateFromUTC(dateString);
         long milliSeconds = getEpochTime(date.getTime());
+        assertEquals(80829000, milliSeconds);
+    }
+
+    @Test
+    public void shouldConvertDateToMilliSecondsInGivenTimezone() throws ParseException {
+        Date date = convertToLocalDateFromUTC("2017-03-15T16:57:09.0Z");
+        long milliSeconds = getEpochTime(date.getTime(), ZoneId.of("Asia/Kolkata"));
         assertEquals(80829000, milliSeconds);
     }
 

--- a/api/src/test/java/org/openmrs/module/appointments/util/LocationUtilTest.java
+++ b/api/src/test/java/org/openmrs/module/appointments/util/LocationUtilTest.java
@@ -1,0 +1,63 @@
+package org.openmrs.module.appointments.util;
+
+import org.junit.Test;
+import org.openmrs.Location;
+import org.openmrs.LocationAttribute;
+import org.openmrs.LocationAttributeType;
+
+import java.time.ZoneId;
+import java.util.Collections;
+import java.util.Optional;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class LocationUtilTest {
+
+    private Location locationWithTimezone(String zoneId) {
+        LocationAttributeType attrType = mock(LocationAttributeType.class);
+        when(attrType.getName()).thenReturn("timeZone");
+        LocationAttribute attr = mock(LocationAttribute.class);
+        when(attr.getAttributeType()).thenReturn(attrType);
+        when(attr.getValue()).thenReturn(zoneId);
+        Location location = mock(Location.class);
+        when(location.getActiveAttributes()).thenReturn(Collections.singletonList(attr));
+        return location;
+    }
+
+    @Test
+    public void shouldReturnEmptyWhenLocationIsNull() {
+        Optional<ZoneId> result = LocationUtil.getLocationZone(null);
+        assertFalse(result.isPresent());
+    }
+
+    @Test
+    public void shouldReturnEmptyWhenLocationHasNoTimezoneAttribute() {
+        Location location = mock(Location.class);
+        when(location.getActiveAttributes()).thenReturn(Collections.emptyList());
+
+        Optional<ZoneId> result = LocationUtil.getLocationZone(location);
+        assertFalse(result.isPresent());
+    }
+
+    @Test
+    public void shouldReturnZoneIdWhenLocationHasValidTimezoneAttribute() {
+        Location location = locationWithTimezone("Asia/Kolkata");
+
+        Optional<ZoneId> result = LocationUtil.getLocationZone(location);
+        assertTrue(result.isPresent());
+        assertEquals(ZoneId.of("Asia/Kolkata"), result.get());
+    }
+
+    @Test
+    public void shouldReturnEmptyWhenTimezoneAttributeValueIsInvalid() {
+        Location location = locationWithTimezone("Invalid/Zone");
+        when(location.getName()).thenReturn("Test Location");
+
+        Optional<ZoneId> result = LocationUtil.getLocationZone(location);
+        assertFalse(result.isPresent());
+    }
+}


### PR DESCRIPTION
## Ticket 

https://bahmni.atlassian.net/browse/BAH-4840

## Description

**Unavailability period conflict detection:**
Previously, AppointmentServiceUnavailabilityConflict only checked whether an appointment fell outside the service's defined weekly hours. 
Appointments are now validated against AppointmentUnavailability records. The conflict is evaluated at multiple levels — date/time, location, service, and provider. If an unavailability block is defined for a specific location, service, or provider, it only conflicts with matching appointments. If no provider is specified, only the date/time, location, and service are used to determine whether a conflict exists.

**Timezone-aware service hours comparison:**
Service hours (weekly availability slots and start/end times) are now compared using the timezone derived from the appointment's location. If the appointment's location has no timezone configured, the service's location timezone is used. If neither is available, the system default is applied. 
Previously, all service hours comparisons used the system default timezone regardless of where the appointment was scheduled, which could produce incorrect conflict results for appointments in a different timezone than the server.

**Overnight and multi-day unavailability overlap:**
The overlap check previously worked by first verifying that the appointment date fell within the unavailability date range, then separately checking whether the appointment's clock times overlapped with the unavailability's clock times. This two-step approach broke down for unavailability periods that span midnight or multiple days, because the start and end times belong to different calendar dates. For example, an unavailability from 28-Jun 18:00 to 29-Jun 09:00 — when checked against a 29-Jun 08:00 appointment — would compare 08:30 against 18:00 as bare clock times and conclude there is no overlap, even though the appointment clearly falls within the blocked period.

The fix replaces this with a single `ZonedDateTime` interval comparison: the unavailability's start date/time and end date/time are each constructed as a full timestamp in the appointment's timezone, and the check becomes `apptStart.isBefore(unavailEnd) && apptEnd.isAfter(unavailStart)`. This is the standard interval overlap formula and correctly handles same-day, overnight, and multi-day unavailability periods without any special casing.